### PR TITLE
Stop the stack being made executable under Linux

### DIFF
--- a/libpolyml/x86asm.asm
+++ b/libpolyml/x86asm.asm
@@ -792,6 +792,13 @@ ENDIF
 
 ENDIF
 
+;# Mark the stack as non-executable when compiling for Linux
+IFDEF __linux__
+IFDEF __ELF__
+.section .note.GNU-stack, "", @progbits
+ENDIF
+ENDIF
+
 ;#
 ;# CODE STARTS HERE
 ;#


### PR DESCRIPTION
GNU as marks the stack as executable by default unless told otherwise, which this patch does. Tested under Linux (it compiles and runs `fun id x = x; id "foo";` in the interpreter). I don't have access to a Windows machine to test, but I'm hoping I got everything right so that MASM just skips over it.