### PR TITLE
Compile in x86-64 OpenBSD.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -305,7 +305,10 @@ AC_CHECK_TYPES([IMAGE_FILE_HEADER],
             [polyexport=elf],
               [AC_CHECK_HEADER([mach-o/reloc.h],
                   [AC_DEFINE([HAVE_MACH_O_RELOC_H], [], [Define to 1 if you have the <mach-o/reloc.h> header file.])]
-                          [polyexport=macho]
+                          [polyexport=macho],
+                      [AC_CHECK_HEADERS([elf_abi.h machine/reloc.h],
+                          [AC_DEFINE([HAVE_ELF_ABI_H], [], [Define to 1 if you have <elf_abi.h> and <machine/reloc.h> header files.])]
+                              [polyexport=elf] )]
                 )]
     )],
     [#include <windows.h>]

--- a/libpolyml/elfexport.cpp
+++ b/libpolyml/elfexport.cpp
@@ -52,8 +52,33 @@
 #define ASSERT(x)
 #endif
 
-// If we haven't got elf.h we shouldn't be building this.
+#ifdef HAVE_ELF_H
 #include <elf.h>
+#elif defined(HAVE_ELF_ABI_H)
+#include <elf_abi.h>
+#include <machine/reloc.h>
+
+#ifndef EM_X86_64
+#define EM_X86_64 EM_AMD64
+#endif
+
+#if defined(HOSTARCHITECTURE_X86_64)
+
+#ifndef R_386_PC32
+#define R_386_PC32 R_X86_64_PC32
+#endif
+
+#ifndef R_386_32
+#define R_386_32 R_X86_64_32
+#endif
+
+#ifndef R_X86_64_64
+#define R_X86_64_64 R_X86_64_64
+#endif
+
+#endif /* HOSTARCHITECTURE_X86_64 */
+
+#endif
 
 // Solaris seems to put processor-specific constants in separate files
 #ifdef HAVE_SYS_ELF_SPARC_H

--- a/libpolyml/elfexport.h
+++ b/libpolyml/elfexport.h
@@ -27,7 +27,14 @@
 
 #include "scanaddrs.h" // For base class
 #include "exporter.h"
+
+#ifdef HAVE_ELF_H
 #include <elf.h>
+#endif
+
+#ifdef HAVE_ELF_ABI_H
+#include <elf_abi.h>
+#endif
 
 // Select 32 or 64 bit version depending on the word length
 #if (SIZEOF_VOIDP == 8)

--- a/libpolyml/exporter.cpp
+++ b/libpolyml/exporter.cpp
@@ -76,7 +76,7 @@
 
 #ifdef HAVE_PECOFF
 #include "pecoffexport.h"
-#elif defined(HAVE_ELF_H)
+#elif defined(HAVE_ELF_H) || defined(HAVE_ELF_ABI_H)
 #include "elfexport.h"
 #elif defined(HAVE_MACH_O_RELOC_H)
 #include "machoexport.h"
@@ -540,7 +540,7 @@ Handle exportNative(TaskData *taskData, Handle args)
 #endif
     PECOFFExport exports;
     exporter(taskData, args, extension, &exports);
-#elif defined(HAVE_ELF_H)
+#elif defined(HAVE_ELF_H) || defined(HAVE_ELF_ABI_H)
     // Most Unix including Linux, FreeBSD and Solaris.
     const char *extension = ".o";
     ELFExport exports;

--- a/libpolyml/x86_dep.cpp
+++ b/libpolyml/x86_dep.cpp
@@ -1566,8 +1566,14 @@ bool X86TaskData::GetPCandSPFromContext(SIGNALCONTEXT *context, PolyWord * &sp, 
 #endif /* HOSTARCHITECTURE_X86_64 */
 #endif
 #elif defined(HAVE_STRUCT_SIGCONTEXT)
+#if defined(HOSTARCHITECTURE_X86_64) && defined(__OpenBSD__)
+    // CPP defines missing in amd64/signal.h in OpenBSD
+    pc = (byte*)context->sc_rip;
+    sp = (PolyWord*)context->sc_rsp;
+#else // !HOSTARCHITEXTURE_X86_64 || !defined(__OpenBSD__)
     pc = (byte*)context->sc_pc;
     sp = (PolyWord*)context->sc_sp;
+#endif
 #else
     // Can't get context.
     return false;


### PR DESCRIPTION
this patche make it possible to use polyml under x86-64 OpenBSD. Main differences are the elf_abi.h header and sigcontext. As a caveat, this does require a configure script refresh.