### PR TITLE
Use conventional check rule in Makefile for running test suite

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -135,6 +135,8 @@ clean-local:
 	rm -f *.obj polytemp.txt polyc
 
 # Run tests
-tests: all
+check-local: all
 	echo "val () = use \"$(srcdir)/Tests/RunTests\"; val () = OS.Process.exit(if runTests \"$(srcdir)/Tests\" then OS.Process.success else OS.Process.failure):unit;" | ./poly
 
+# Retain this target for backwards compatibility
+tests: check


### PR DESCRIPTION
The check rule is conventionally used for running test suites, and automake likes to adhere to this convention. Like many of the other rules, it has an auto-generated check rule based on the contents of various macros, but also a check-local rule for defining custom tests, which check has as a prerequisite.