### PR TITLE
Add support for little-endian MIPS

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -554,31 +554,31 @@
 /* Define to 1 if the system has the type `_Bool'. */
 #undef HAVE__BOOL
 
-/* Define if the host is an ARM (64 bit) */
+/* Define if the host is an ARM (64-bit) */
 #undef HOSTARCHITECTURE_AARCH64
 
-/* Define if the host is an ARM (32 bit) */
+/* Define if the host is an ARM (32-bit) */
 #undef HOSTARCHITECTURE_ARM
 
-/* Define if the host is Itanium */
+/* Define if the host is an Itanium */
 #undef HOSTARCHITECTURE_IA64
 
-/* Define if the host is Mips (32-bit) */
+/* Define if the host is a MIPS (32-bit) */
 #undef HOSTARCHITECTURE_MIPS
 
-/* Define if the host is a Power PC (32 bit) */
+/* Define if the host is a PowerPC (32-bit) */
 #undef HOSTARCHITECTURE_PPC
 
-/* Define if the host is a Power PC (64 bit) */
+/* Define if the host is a PowerPC (64-bit) */
 #undef HOSTARCHITECTURE_PPC64
 
-/* Define if the host is a Sparc (32 bit) */
+/* Define if the host is a Sparc (32-bit) */
 #undef HOSTARCHITECTURE_SPARC
 
-/* Define if the host is an X86 (32 bit) */
+/* Define if the host is an X86 (32-bit) */
 #undef HOSTARCHITECTURE_X86
 
-/* Define if the host is an X86 (64 bit) */
+/* Define if the host is an X86 (64-bit) */
 #undef HOSTARCHITECTURE_X86_64
 
 /* Define if using the interpreter */

--- a/configure.ac
+++ b/configure.ac
@@ -141,7 +141,7 @@ AC_PATH_X
 if test "x${with_x}" = "xyes"; then
 
     AC_DEFINE([WITH_XWINDOWS], [1], [Define if the X-Windows interface should be built])
-    
+
     if test "$x_includes" != "" ; then
     if test  "$x_includes" != "NONE" ; then
         CFLAGS="$CFLAGS -I$x_includes"
@@ -157,7 +157,7 @@ if test "x${with_x}" = "xyes"; then
     AC_CHECK_LIB(X11, XCreateGC)
     AC_CHECK_LIB(Xt, XtMalloc)
     AC_CHECK_LIB(Xext, XextAddDisplay)
-    
+
     if test "$xm_includes" != "" ; then
     if test "$xm_includes" != "NONE" ; then
         CFLAGS="$CFLAGS -I$xm_includes"
@@ -250,8 +250,8 @@ if test "x$with_system_libffi" = "xyes"; then
                      [ AC_MSG_FAILURE([--with-system-libffi was given, but ffi.h header file cannot be found]) ])
              ],
              [AC_MSG_FAILURE([--with-system-libffi was given, but the ffi library is not installed])]
-       ) 
-       ] 
+       )
+       ]
     )
 else
 # Use internal libffi
@@ -416,41 +416,41 @@ AC_ARG_ENABLE([native-codegeneration],
 
 case "${host_cpu}" in
       i[[3456]]86*)
-            AC_DEFINE([HOSTARCHITECTURE_X86], [1], [Define if the host is an X86 (32 bit)])
+            AC_DEFINE([HOSTARCHITECTURE_X86], [1], [Define if the host is an X86 (32-bit)])
             polyarch=i386
             ;;
       x86_64* | amd64*)
-            AC_DEFINE([HOSTARCHITECTURE_X86_64], [1], [Define if the host is an X86 (64 bit)])
+            AC_DEFINE([HOSTARCHITECTURE_X86_64], [1], [Define if the host is an X86 (64-bit)])
             polyarch=x86_64
             ;;
       sparc*)
-            AC_DEFINE([HOSTARCHITECTURE_SPARC], [1], [Define if the host is a Sparc (32 bit)])
+            AC_DEFINE([HOSTARCHITECTURE_SPARC], [1], [Define if the host is a Sparc (32-bit)])
             polyarch=interpret
             ;;
       powerpc64* | ppc64*)
-            AC_DEFINE([HOSTARCHITECTURE_PPC64], [1], [Define if the host is a Power PC (64 bit)])
+            AC_DEFINE([HOSTARCHITECTURE_PPC64], [1], [Define if the host is a PowerPC (64-bit)])
             polyarch=interpret
             ;;
       power* | ppc*)
-            AC_DEFINE([HOSTARCHITECTURE_PPC], [1], [Define if the host is a Power PC (32 bit)])
+            AC_DEFINE([HOSTARCHITECTURE_PPC], [1], [Define if the host is a PowerPC (32-bit)])
             polyarch=interpret
             ;;
       arm*)
-            AC_DEFINE([HOSTARCHITECTURE_ARM], [1], [Define if the host is an ARM (32 bit)])
+            AC_DEFINE([HOSTARCHITECTURE_ARM], [1], [Define if the host is an ARM (32-bit)])
             polyarch=interpret
             ;;
       aarch64*)
-            AC_DEFINE([HOSTARCHITECTURE_AARCH64], [1], [Define if the host is an ARM (64 bit)])
+            AC_DEFINE([HOSTARCHITECTURE_AARCH64], [1], [Define if the host is an ARM (64-bit)])
             polyarch=interpret
             ;;
       ia64*)
-            AC_DEFINE([HOSTARCHITECTURE_IA64], [1], [Define if the host is Itanium])
+            AC_DEFINE([HOSTARCHITECTURE_IA64], [1], [Define if the host is an Itanium])
             polyarch=interpret
-        ;;
+            ;;
       mips*)
-            AC_DEFINE([HOSTARCHITECTURE_MIPS], [1], [Define if the host is Mips (32-bit)])
-             polyarch=interpret
-        ;;
+            AC_DEFINE([HOSTARCHITECTURE_MIPS], [1], [Define if the host is a MIPS (32-bit)])
+            polyarch=interpret
+            ;;
       *) AC_MSG_ERROR([Poly/ML is not supported for this architecture]) ;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -447,7 +447,7 @@ case "${host_cpu}" in
             AC_DEFINE([HOSTARCHITECTURE_IA64], [1], [Define if the host is Itanium])
             polyarch=interpret
         ;;
-      mips)
+      mips*)
             AC_DEFINE([HOSTARCHITECTURE_MIPS], [1], [Define if the host is Mips (32-bit)])
              polyarch=interpret
         ;;

--- a/winconfig.h
+++ b/winconfig.h
@@ -448,7 +448,7 @@
 
 /* Define to 1 if you have the `sysctlbyname' function. */
 #undef HAVE_SYSCTLBYNAME
- 
+
 /* Define to 1 if the system has the type
    `SYSTEM_LOGICAL_PROCESSOR_INFORMATION'. */
 #undef HAVE_SYSTEM_LOGICAL_PROCESSOR_INFORMATION
@@ -593,22 +593,31 @@
 /* Define to 1 if the system has the type `_Bool'. */
 #undef HAVE__BOOL
 
-/* Define if the host is an ARM (32 bit) */
+/* Define if the host is an ARM (64-bit) */
+/*#undef HOSTARCHITECTURE_AARCH64*/
+
+/* Define if the host is an ARM (32-bit) */
 /*#undef HOSTARCHITECTURE_ARM*/
 
-/* Define if the host is Itanium */
+/* Define if the host is an Itanium */
 /*#undef HOSTARCHITECTURE_IA64*/
 
-/* Define if the host is a Power PC (32 bit) */
+/* Define if the host is a MIPS (32-bit) */
+/*#undef HOSTARCHITECTURE_MIPS*/
+
+/* Define if the host is a PowerPC (32-bit) */
 /*#undef HOSTARCHITECTURE_PPC*/
 
-/* Define if the host is a Sparc (32 bit) */
+/* Define if the host is a PowerPC (64-bit) */
+/*#undef HOSTARCHITECTURE_PPC64*/
+
+/* Define if the host is a Sparc (32-bit) */
 /*#undef HOSTARCHITECTURE_SPARC*/
 
-/* Define if the host is an X86 (32 bit) */
+/* Define if the host is an X86 (32-bit) */
 /*#undef HOSTARCHITECTURE_X86*/
 
-/* Define if the host is an X86 (64 bit) */
+/* Define if the host is an X86 (64-bit) */
 /*#undef HOSTARCHITECTURE_X86_64*/
 
 /* Define to 1 if `lstat' dereferences a symlink specified with a trailing
@@ -727,7 +736,7 @@
 #undef size_t
 
 /* Define to `int' if <sys/types.h> does not define. */
-// There is an SSIZE_T 
+// There is an SSIZE_T
 #undef ssize_t
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
Little-endian MIPS is identified by mipsel, so this makes the configure script treat mips* as MIPS. I have also included a couple of cleanup commits; I don't know if these are desired, so I can remove them from the pull request (or alter them) if you would like. The current `configure` is outdated compared to `configure.ac`, and so will need to be regenerated.