### PR TITLE
Don't support rounding modes for soft-float systems

### DIFF
--- a/Tests/Succeed/Test121.ML
+++ b/Tests/Succeed/Test121.ML
@@ -2,7 +2,7 @@
    and compiled code. *)
 fun check x = if x then () else raise Fail "Wrong";
 open IEEEReal;
-setRoundingMode(TO_POSINF);
+setRoundingMode(TO_POSINF) handle Fail _ => raise Fail "Skip Test";
 check(getRoundingMode() = TO_POSINF);
 val pos = 1.0/3.0;
 check(pos * 3.0 > 1.0);

--- a/libpolyml/reals.cpp
+++ b/libpolyml/reals.cpp
@@ -370,9 +370,28 @@ static Handle powerOf(TaskData *mdTaskData, Handle args)
 #define POLY_ROUND_UPWARD       2
 #define POLY_ROUND_TOZERO       3
 
+#if defined(__SOFTFP__)
+// soft-float lacks proper rounding mode support
+// While some systems will support fegetround/fesetround, it will have no
+// effect on the actual rounding performed, as the software implementation only
+// ever rounds to nearest.
+static int getrounding(TaskData *)
+{
+    return POLY_ROUND_TONEAREST;
+}
+
+static void setrounding(TaskData *taskData, Handle args)
+{
+    switch (get_C_long(taskData, DEREFWORDHANDLE(args)))
+    {
+    case POLY_ROUND_TONEAREST: return; // The only mode supported
+    }
+    raise_exception_string(taskData, EXC_Fail, "Setting the floating point rounding control to a value other than TO_NEAREST is not supported for software-based floating point implementations");
+}
+
 // It would be nice to be able to use autoconf to test for these as functions
 // but they are frequently inlined 
-#if defined(HAVE_FENV_H)
+#elif defined(HAVE_FENV_H)
 // C99 version.  This is becoming the most common.
 static int getrounding(TaskData *)
 {


### PR DESCRIPTION
On armel, floating point operations are implemented in software.
However, the implementation always rounds to nearest. If the system has
a hardware FPU, it will support setting the rounding mode to any valid
value, and subsequent gets will return this value, but it will have no
effect on the actual rounding performed. If the system doesn't have a
hardware FPU, it will only allow the rounding mode to be set to
FE_NEAREST, and getting the rounding mode will always return this.

Since rounding may not be supported, the floating point rounding mode
test needs to be skipped on unsupported systems. This is implemented by
raising Fail "Skip Test", which is caught in runTests.