### PR TITLE
Mark polyexport.o as CPIC on MIPS when code is position-independent

### DIFF
--- a/libpolyml/elfexport.cpp
+++ b/libpolyml/elfexport.cpp
@@ -393,6 +393,9 @@ void ELFExport::exportStore(void)
 #elif defined(HOSTARCHITECTURE_MIPS)
     fhdr.e_machine = EM_MIPS;
     directReloc = R_MIPS_32;
+#ifdef __PIC__
+    fhdr.e_flags = EF_MIPS_CPIC;
+#endif
     useRela = true;
 #else
 #error "No support for exporting on this architecture"


### PR DESCRIPTION
Fixes ld warning about linking abicalls files with non-abicalls files