### PR TITLE
Define unixConstVec as unsigned

### DIFF
--- a/libpolyml/unix_specific.cpp
+++ b/libpolyml/unix_specific.cpp
@@ -135,7 +135,7 @@
 #define SIZEOF(x) (sizeof(x)/sizeof(PolyWord))
 
 /* Table of constants returned by call 4. */
-static int unixConstVec[] =
+static unsigned unixConstVec[] =
 {
     /* Error codes. */
     E2BIG, /* 0 */


### PR DESCRIPTION
Fixes narrowing conversion inside braces on PowerPC with GCC 6. NOFLSH is 0x80000000u on PowerPC, but sizeof(int) is 4, so casting to an int is a narrowing conversion and leads to a negative entry. I don't know whether the negative entry itself is harmless, but with GCC 6 defaulting to C++11, narrowing conversions inside `{ }` are errors, so it fails to compile.