### PR TITLE
Various trivial tweaks.

### DIFF
--- a/libpolyml/basicio.cpp
+++ b/libpolyml/basicio.cpp
@@ -379,7 +379,7 @@ Handle make_stream_entry(TaskData *taskData)
 */ 
 void free_stream_entry(POLYUNSIGNED stream_no)
 {
-    ASSERT(0 <= stream_no && stream_no < max_streams);
+    ASSERT(stream_no < max_streams);
 
     ioLock.Lock();
     basic_io_vector[stream_no].token  = 0;

--- a/libpolyml/bitmap.cpp
+++ b/libpolyml/bitmap.cpp
@@ -108,9 +108,6 @@ void Bitmap::SetBits(POLYUNSIGNED bitno, POLYUNSIGNED length)
         length = stop_bit_index - 8;
     }
     
-    /* Invariant: 0 <= length */
-    ASSERT(length >= 0);
-    
     /* Set as many full bytes as possible */
     while (8 <= length)
     {
@@ -123,7 +120,7 @@ void Bitmap::SetBits(POLYUNSIGNED bitno, POLYUNSIGNED length)
     }
     
     /* Invariant: 0 <= length < 8 */
-    ASSERT(length >= 0 && length < 8);
+    ASSERT(length < 8);
     if (length == 0) return;
     
     /* Invariant: 0 < length < 8 */

--- a/libpolyml/foreign.cpp
+++ b/libpolyml/foreign.cpp
@@ -1497,7 +1497,7 @@ static Handle call_sym_and_convert (TaskData *taskData, Handle triple)
 static void callbackEntryPt(ffi_cif *cif, void *ret, void* args[], void *data)
 {
     uintptr_t cbIndex = (uintptr_t)data;
-    ASSERT(cbIndex >= 0 && cbIndex < callBackEntries);
+    ASSERT(cbIndex < callBackEntries);
     struct _cbStructEntry *cbEntry = &callbackTable[cbIndex];
     // We should get the task data for the thread that is running this code.
     // If this thread has been created by the foreign code we will have to

--- a/libpolyml/memmgr.cpp
+++ b/libpolyml/memmgr.cpp
@@ -836,7 +836,7 @@ void MemMgr::AddTreeRange(SpaceTree **tt, MemSpace *space, uintptr_t startS, uin
 
     const unsigned shift = (sizeof(void*)-1) * 8; // Takes the high-order byte
     uintptr_t r = startS >> shift;
-    ASSERT(r >= 0 && r < 256);
+    ASSERT(r < 256);
     const uintptr_t s = endS == 0 ? 256 : endS >> shift;
     ASSERT(s >= r && s <= 256);
 

--- a/libpolyml/polyffi.cpp
+++ b/libpolyml/polyffi.cpp
@@ -641,7 +641,7 @@ static Handle mkAbitab(TaskData *taskData, void *arg, char *p)
 static void callbackEntryPt(ffi_cif *cif, void *ret, void* args[], void *data)
 {
     uintptr_t cbIndex = (uintptr_t)data;
-    ASSERT(cbIndex >= 0 && cbIndex < callBackEntries);
+    ASSERT(cbIndex < callBackEntries);
     // We should get the task data for the thread that is running this code.
     // If this thread has been created by the foreign code we will have to
     // create a new one here.

--- a/libpolyml/processes.cpp
+++ b/libpolyml/processes.cpp
@@ -590,7 +590,7 @@ Handle Processes::ThreadDispatch(TaskData *taskData, Handle args, Handle code)
     default:
         {
             char msg[100];
-            sprintf(msg, "Unknown thread function: %d", c);
+            sprintf(msg, "Unknown thread function: %u", c);
             raise_fail(taskData, msg);
             return 0;
         }

--- a/libpolyml/sharedata.cpp
+++ b/libpolyml/sharedata.cpp
@@ -58,7 +58,7 @@
 #include "diagnostics.h"
 
 /*
-This code was largely written by Simon Finn as a database improver for the the
+This code was largely written by Simon Finn as a database improver for the
 memory-mapped persistent store version.  The aim is that where two immutable
 objects (cells) contain the same data (i.e. where ML equality would say they
 were equal) they should be merged so that only a single object is retained.


### PR DESCRIPTION
This PR contains some trivial changes that do some clean up and remove some compiler warnings. I haven't contributed to Poly/ML before, so if my changes are unacceptable or in a suboptimal format, please let me know and I can adjust them. Thanks for your time.

----

I was also going to change patterns like `malloc` then `memset 0` into a call to `calloc` in situations like in bitmap.cpp. A single call to `calloc` has the potential to be slightly faster, though I would not necessarily expect it to make a noticeable difference to macro benchmarks. Please let me know if you'd like me to include that in this PR or if you'd prefer not to make this change. Thanks!