### PR TITLE
Shrink the on-disk size of headers in saved states

### DIFF
--- a/libpolyml/savestate.cpp
+++ b/libpolyml/savestate.cpp
@@ -144,7 +144,7 @@ private:
  */
 
 #define SAVEDSTATESIGNATURE "POLYSAVE"
-#define SAVEDSTATEVERSION   1
+#define SAVEDSTATEVERSION   2
 
 // File header for a saved state file.  This appears as the first entry
 // in the file.
@@ -164,9 +164,7 @@ typedef struct _savedStateHeader
     size_t      stringTableSize;        // Size of string table
     unsigned    parentNameEntry;        // Position of parent name in string table (0 if top)
     time_t      timeStamp;            // The time stamp for this file.
-    uintptr_t   fileSignature;        // The signature for this file.
     time_t      parentTimeStamp;      // The time stamp for the parent.
-    uintptr_t   parentSignature;      // The signature for the parent.
 } SavedStateHeader;
 
 // Entry for segment table.  This describes the segments on the disc that

--- a/libpolyml/savestate.cpp
+++ b/libpolyml/savestate.cpp
@@ -1260,7 +1260,7 @@ Handle ShowParent(TaskData *taskData, Handle hFileName)
 
 // Module system
 #define MODULESIGNATURE "POLYMODU"
-#define MODULEVERSION   1
+#define MODULEVERSION   2
 
 typedef struct _moduleHeader
 {
@@ -1274,10 +1274,7 @@ typedef struct _moduleHeader
     // These entries contain the real data.
     off_t       segmentDescr;           // Position of segment descriptor table
     unsigned    segmentDescrCount;      // Number of segment descriptors in the table
-    off_t       stringTable;            // Pointer to the string table (zero if none)
-    size_t      stringTableSize;        // Size of string table
     time_t      timeStamp;              // The time stamp for this file.
-    uintptr_t   fileSignature;          // The signature for this file.
     time_t      executableTimeStamp;    // The time stamp for the parent executable.
     // Root
     uintptr_t   rootSegment;


### PR DESCRIPTION
This PR removes unused members from the save state structs, reducing the size of exported heaps, though admittedly not by a great amount. I was also considering re-arranging the struct members to more tightly pack them (e.g. `unsigned` is 4 bytes on x86_64 which leaves an intermediate 4 bytes of unused padding in between a lone `unsigned` and a following 8 byte member).

Thanks for merging my last PR, and I realise this is a much more controversial change. My thinking is essentially to avoid repeatedly writing this unused (zeroed) data and minimise saved heap sizes in any way possible. My overall motivation is reducing the size of heaps generated by Isabelle/HOL. I realise this change alone has very little impact on the total heap size, but it seemed like clear low hanging fruit to me.