### PR TITLE
Avoid some calls to memset.

### DIFF
--- a/libpolyml/bitmap.cpp
+++ b/libpolyml/bitmap.cpp
@@ -60,8 +60,7 @@ bool Bitmap::Create(POLYUNSIGNED bits)
 {
     free(m_bits); // Any previous data
     size_t bytes = (bits+7) >> 3;
-    m_bits = (unsigned char*)malloc(bytes);
-    if (m_bits != 0) memset(m_bits, 0, bytes);
+    m_bits = (unsigned char*)calloc(bytes, sizeof(unsigned char));
     return m_bits != 0;
 }
 

--- a/libpolyml/elfexport.cpp
+++ b/libpolyml/elfexport.cpp
@@ -273,9 +273,8 @@ void ELFExport::writeSymbol(const char *symbolName, long value, long size, int b
 // Set the file alignment.
 void ELFExport::alignFile(int align)
 {
-    char pad[32]; // Maximum alignment
+    char pad[32] = {0}; // Maximum alignment
     int offset = ftell(exportFile);
-    memset(pad, 0, sizeof(pad));
     if ((offset % align) == 0) return;
     fwrite(&pad, align - (offset % align), 1, exportFile);
 }

--- a/libpolyml/machoexport.cpp
+++ b/libpolyml/machoexport.cpp
@@ -234,9 +234,8 @@ void MachoExport::writeSymbol(const char *symbolName, unsigned char nType, unsig
 // Set the file alignment.
 void MachoExport::alignFile(int align)
 {
-    char pad[32]; // Maximum alignment
+    char pad[32] = {0}; // Maximum alignment
     int offset = ftell(exportFile);
-    memset(pad, 0, sizeof(pad));
     if ((offset % align) == 0) return;
     fwrite(&pad, align - (offset % align), 1, exportFile);
 }

--- a/libpolyml/pecoffexport.cpp
+++ b/libpolyml/pecoffexport.cpp
@@ -167,9 +167,8 @@ void PECOFFExport::ScanConstant(byte *addr, ScanRelocationKind code)
 // Set the file alignment.
 void PECOFFExport::alignFile(int align)
 {
-    char pad[32]; // Maximum alignment
+    char pad[32] = {0}; // Maximum alignment
     int offset = ftell(exportFile);
-    memset(pad, 0, sizeof(pad));
     if ((offset % align) == 0) return;
     fwrite(&pad, align - (offset % align), 1, exportFile);
 }

--- a/libpolyml/polyffi.cpp
+++ b/libpolyml/polyffi.cpp
@@ -331,12 +331,11 @@ Handle poly_ffi(TaskData *taskData, Handle args, Handle code)
             // If we need the elements add space for the elements plus
             // one extra for the zero terminator.
             if (nElems != 0) space += (nElems+1) * sizeof(ffi_type *);
-            ffi_type *result = (ffi_type*)malloc(space);
+            ffi_type *result = (ffi_type*)calloc(1, space);
             // Raise an exception rather than returning zero.
             if (result == 0) raise_syscall(taskData, "Insufficient memory", ENOMEM);
             ffi_type **elem = 0;
             if (nElems != 0) elem = (ffi_type **)(result+1);
-            memset(result, 0, sizeof(ffi_type)); // Zero it in case they add fields
             result->size = size;
             result->alignment = align;
             result->type = type;

--- a/libpolyml/processes.cpp
+++ b/libpolyml/processes.cpp
@@ -2083,9 +2083,8 @@ static unsigned LinuxNumPhysicalProcessors(void)
     unsigned nProcs = NumberOfProcessors();
     // If there's only one we don't need to check further.
     if (nProcs <= 1) return nProcs;
-    long *cpus = (long*)malloc(nProcs * sizeof(long));
+    long *cpus = (long*)calloc(nProcs, sizeof(long));
     if (cpus == 0) return 0;
-    memset(cpus, 0, nProcs * sizeof(long));
 
     FILE *cpuInfo = fopen("/proc/cpuinfo", "r");
     if (cpuInfo == NULL) { free(cpus); return 0; }

--- a/libpolyml/sighandler.cpp
+++ b/libpolyml/sighandler.cpp
@@ -478,8 +478,7 @@ static void *SignalDetectionThread(void *)
     sigset_t active_signals;    
     sigfillset(&active_signals);
     pthread_sigmask(SIG_SETMASK, &active_signals, NULL);
-    int readSignals[NSIG];
-    memset(readSignals, 0, sizeof(readSignals));
+    int readSignals[NSIG] = {0};
 
     while (true)
     {

--- a/libpolyml/statistics.cpp
+++ b/libpolyml/statistics.cpp
@@ -221,9 +221,8 @@ void Statistics::Init()
 #endif
     {
         // If we just want the statistics locally.
-        statMemory = (unsigned char*)malloc(STATS_SPACE);
+        statMemory = (unsigned char*)calloc(STATS_SPACE, sizeof(unsigned char));
         if (statMemory == 0) return;
-        memset(statMemory, 0, STATS_SPACE);
     }
 #endif
     


### PR DESCRIPTION
This PR uses `calloc` or explicit array initialisation to avoid some calls to `memset`, with the aim of potential performance improvements and code clarification. Note that some of these changes do touch performance critical code (e.g. bitmap.cpp).

These changes pass the test suite, but I'm aware that the test suite does not exercise some of the affected code. I also have only x86_64 Linux machines to test on. If you have a more in-depth way of validating these changes, please let me know and I can run further tests.

