### PR TITLE
Add support for 64-bit MIPS

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -566,6 +566,9 @@
 /* Define if the host is a MIPS (32-bit) */
 #undef HOSTARCHITECTURE_MIPS
 
+/* Define if the host is a MIPS (64-bit) */
+#undef HOSTARCHITECTURE_MIPS64
+
 /* Define if the host is a PowerPC (32-bit) */
 #undef HOSTARCHITECTURE_PPC
 

--- a/configure.ac
+++ b/configure.ac
@@ -447,6 +447,10 @@ case "${host_cpu}" in
             AC_DEFINE([HOSTARCHITECTURE_IA64], [1], [Define if the host is an Itanium])
             polyarch=interpret
             ;;
+      mips64*)
+            AC_DEFINE([HOSTARCHITECTURE_MIPS64], [1], [Define if the host is a MIPS (64-bit)])
+            polyarch=interpret
+            ;;
       mips*)
             AC_DEFINE([HOSTARCHITECTURE_MIPS], [1], [Define if the host is a MIPS (32-bit)])
             polyarch=interpret

--- a/libpolyml/elfexport.cpp
+++ b/libpolyml/elfexport.cpp
@@ -154,7 +154,15 @@ PolyWord ELFExport::createRelocation(PolyWord p, void *relocAddr)
         ElfXX_Rela reloc;
         // Set the offset within the section we're scanning.
         setRelocationAddress(relocAddr, &reloc.r_offset);
+#ifdef HOSTARCHITECTURE_MIPS64
+        reloc.r_sym = AreaToSym(addrArea);
+        reloc.r_ssym = 0;
+        reloc.r_type = directReloc;
+        reloc.r_type2 = 0;
+        reloc.r_type3 = 0;
+#else
         reloc.r_info = ELFXX_R_INFO(AreaToSym(addrArea), directReloc);
+#endif
         reloc.r_addend = offset;
         fwrite(&reloc, sizeof(reloc), 1, exportFile);
         relocationCount++;
@@ -163,7 +171,15 @@ PolyWord ELFExport::createRelocation(PolyWord p, void *relocAddr)
     else {
         ElfXX_Rel reloc;
         setRelocationAddress(relocAddr, &reloc.r_offset);
+#ifdef HOSTARCHITECTURE_MIPS64
+        reloc.r_sym = AreaToSym(addrArea);
+        reloc.r_ssym = 0;
+        reloc.r_type = directReloc;
+        reloc.r_type2 = 0;
+        reloc.r_type3 = 0;
+#else
         reloc.r_info = ELFXX_R_INFO(AreaToSym(addrArea), directReloc);
+#endif
         fwrite(&reloc, sizeof(reloc), 1, exportFile);
         relocationCount++;
         return PolyWord::FromUnsigned(offset);
@@ -284,7 +300,15 @@ void ELFExport::createStructsRelocation(unsigned sym, POLYUNSIGNED offset, POLYS
     if (useRela)
     {
         ElfXX_Rela reloc;
+#ifdef HOSTARCHITECTURE_MIPS64
+        reloc.r_sym = sym;
+        reloc.r_ssym = 0;
+        reloc.r_type = directReloc;
+        reloc.r_type2 = 0;
+        reloc.r_type3 = 0;
+#else
         reloc.r_info = ELFXX_R_INFO(sym, directReloc);
+#endif
         reloc.r_offset = offset;
         reloc.r_addend = addend;
         fwrite(&reloc, sizeof(reloc), 1, exportFile);
@@ -293,7 +317,15 @@ void ELFExport::createStructsRelocation(unsigned sym, POLYUNSIGNED offset, POLYS
     else
     {
         ElfXX_Rel reloc;
+#ifdef HOSTARCHITECTURE_MIPS64
+        reloc.r_sym = sym;
+        reloc.r_ssym = 0;
+        reloc.r_type = directReloc;
+        reloc.r_type2 = 0;
+        reloc.r_type3 = 0;
+#else
         reloc.r_info = ELFXX_R_INFO(sym, directReloc);
+#endif
         reloc.r_offset = offset;
         fwrite(&reloc, sizeof(reloc), 1, exportFile);
         relocationCount++;
@@ -394,6 +426,14 @@ void ELFExport::exportStore(void)
     directReloc = R_MIPS_32;
 #ifdef __PIC__
     fhdr.e_flags = EF_MIPS_CPIC;
+#endif
+    useRela = true;
+#elif defined(HOSTARCHITECTURE_MIPS64)
+    fhdr.e_machine = EM_MIPS;
+    directReloc = R_MIPS_64;
+    fhdr.e_flags = EF_MIPS_ARCH_64;
+#ifdef __PIC__
+    fhdr.e_flags |= EF_MIPS_CPIC;
 #endif
     useRela = true;
 #else

--- a/libpolyml/elfexport.h
+++ b/libpolyml/elfexport.h
@@ -60,6 +60,38 @@
 #define ELFCLASSXX              ELFCLASS32
 #endif
 
+#ifdef HOSTARCHITECTURE_MIPS64
+/* MIPS N64 ABI has a different Elf64_Rel/Rela layout */
+
+typedef struct
+{
+  Elf64_Addr r_offset;      /* Address */
+  Elf64_Word r_sym;         /* Symbol index */
+  unsigned char r_ssym;     /* Special symbol */
+  unsigned char r_type3;    /* Third relocation type */
+  unsigned char r_type2;    /* Second relocation type */
+  unsigned char r_type;     /* First relocation type */
+} Elf64_Mips_Rel;
+
+typedef struct
+{
+  Elf64_Addr r_offset;      /* Address */
+  Elf64_Word r_sym;         /* Symbol index */
+  unsigned char r_ssym;     /* Special symbol */
+  unsigned char r_type3;    /* Third relocation type */
+  unsigned char r_type2;    /* Second relocation type */
+  unsigned char r_type;     /* First relocation type */
+  Elf64_Sxword r_addend;    /* Addend */
+} Elf64_Mips_Rela;
+
+#undef  ElfXX_Rel
+#define ElfXX_Rel   Elf64_Mips_Rel
+#undef  ElfXX_Rela
+#define ElfXX_Rela  Elf64_Mips_Rela
+/* Elf64_Mips_Rel/Rela has no r_info, so this macro is meaningless */
+#undef  ELFXX_R_INFO
+#endif
+
 class TaskData;
 
 class ELFExport: public Exporter, public ScanAddress


### PR DESCRIPTION
Unfortunately the 64-bit MIPS ABI is awkward and defines its own `Elf64_Rel`/`Elf64_Rela` structures, and they don't appear to be defined anywhere in the system headers, so I had to include them in `elfexport.h`. The definition is as in Table 29 of https://www.linux-mips.org/pub/linux/mips/doc/ABI/elf64-2.4.pdf, with `unsigned char` instead of `Elf64_Byte` as it is not defined on my system.