### PR TITLE
Add support for Motorola 68000

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -563,6 +563,9 @@
 /* Define if the host is an Itanium */
 #undef HOSTARCHITECTURE_IA64
 
+/* Define if the host is a Motorola 68000 */
+#undef HOSTARCHITECTURE_M68K
+
 /* Define if the host is a MIPS (32-bit) */
 #undef HOSTARCHITECTURE_MIPS
 

--- a/configure.ac
+++ b/configure.ac
@@ -447,6 +447,10 @@ case "${host_cpu}" in
             AC_DEFINE([HOSTARCHITECTURE_IA64], [1], [Define if the host is an Itanium])
             polyarch=interpret
             ;;
+      m68k*)
+            AC_DEFINE([HOSTARCHITECTURE_M68K], [1], [Define if the host is a Motorola 68000])
+            polyarch=interpret
+            ;;
       mips*)
             AC_DEFINE([HOSTARCHITECTURE_MIPS], [1], [Define if the host is a MIPS (32-bit)])
             polyarch=interpret

--- a/libpolyml/elfexport.cpp
+++ b/libpolyml/elfexport.cpp
@@ -389,6 +389,10 @@ void ELFExport::exportStore(void)
     fhdr.e_machine = EM_AARCH64;
     directReloc = R_AARCH64_ABS64;
     useRela = true;
+#elif defined(HOSTARCHITECTURE_M68K)
+    fhdr.e_machine = EM_68K;
+    directReloc = R_68K_32;
+    useRela = true;
 #elif defined(HOSTARCHITECTURE_MIPS)
     fhdr.e_machine = EM_MIPS;
     directReloc = R_MIPS_32;


### PR DESCRIPTION
Unfortunately, for the test suite to pass, I have to patch glibc to avoid https://sourceware.org/bugzilla/show_bug.cgi?id=19741, as otherwise calls to `gethostbyname` lead to an assertion failure within glibc. It may be that some systems don't run into this and get lucky with pointer alignment, but the one I was using consistently crashed without patching glibc to weaken the failing assertion.