### PR TITLE
Make build reproducible

### DIFF
--- a/libpolyml/elfexport.cpp
+++ b/libpolyml/elfexport.cpp
@@ -115,6 +115,7 @@
 #include "run_time.h"
 #include "version.h"
 #include "polystring.h"
+#include "timing.h"
 
 #define sym_last_local_sym sym_data_section
 
@@ -681,7 +682,7 @@ void ELFExport::exportStore(void)
     // Set the value to be the offset relative to the base of the area.  We have set a relocation
     // already which will add the base of the area.
     exports.rootFunction = useRela ? 0 : (void*)rootOffset;
-    exports.timeStamp = time(NULL);
+    exports.timeStamp = getBuildTime();
     exports.ioSpacing = ioSpacing;
     exports.architecture = machineDependent->MachineArchitecture();
     exports.rtsVersion = POLY_version_number;

--- a/libpolyml/elfexport.cpp
+++ b/libpolyml/elfexport.cpp
@@ -338,9 +338,9 @@ void ELFExport::exportStore(void)
     PolyWord    *p;
     ElfXX_Ehdr fhdr;
     ElfXX_Shdr *sections = 0;
-    unsigned numSections = 6 + 2*memTableEntries;
+    unsigned numSections = 6 + 2*memTableEntries - 1;
     // The symbol table comes at the end.
-    unsigned sect_symtab = sect_data + 2*memTableEntries + 2;
+    unsigned sect_symtab = sect_data + 2*memTableEntries + 2 - 1;
     
     unsigned i;
 
@@ -479,6 +479,7 @@ void ELFExport::exportStore(void)
     // sections[sect_stringtable].sh_offset is set later
     // sections[sect_stringtable].sh_size is set later
 
+    unsigned long bssName = makeStringTableEntry(".bss", &sectionStrings);
     unsigned long dataName = makeStringTableEntry(".data", &sectionStrings);
     unsigned long dataRelName = makeStringTableEntry(useRela ? ".rela.data" : ".rel.data", &sectionStrings);
     unsigned long textName = makeStringTableEntry(".text", &sectionStrings);
@@ -487,41 +488,52 @@ void ELFExport::exportStore(void)
     // Main data sections.  Each one has a relocation section.
     for (i=0; i < memTableEntries; i++)
     {
-        unsigned s = sect_data + i*2;
-        sections[s].sh_type = SHT_PROGBITS;
+        unsigned s = sect_data + i*2 - (i > ioMemEntry ? 1 : 0);
         sections[s].sh_addralign = 8; // 8-byte alignment
 
-        if (memTable[i].mtFlags & MTF_WRITEABLE)
+        if (i == ioMemEntry)
         {
-            // Mutable areas
-            ASSERT(!(memTable[i].mtFlags & MTF_EXECUTABLE)); // Executable areas can't be writable.
-            sections[s].sh_name = dataName;
+            ASSERT(memTable[i].mtFlags & MTF_WRITEABLE);
+            ASSERT(!(memTable[i].mtFlags & MTF_EXECUTABLE));
+            sections[s].sh_name = bssName;
+            sections[s].sh_type = SHT_NOBITS;
             sections[s].sh_flags = SHF_WRITE | SHF_ALLOC;
-            sections[s+1].sh_name = dataRelName; // Name of relocation section
         }
         else
         {
-            // Immutable areas are marked as executable.
-            sections[s].sh_name = textName;
-            sections[s].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
-            sections[s+1].sh_name = textRelName; // Name of relocation section
-        }
-        // sections[s].sh_size is set later
-        // sections[s].sh_offset is set later.
-        // sections[s].sh_size is set later.
+            sections[s].sh_type = SHT_PROGBITS;
+            if (memTable[i].mtFlags & MTF_WRITEABLE)
+            {
+                // Mutable areas
+                ASSERT(!(memTable[i].mtFlags & MTF_EXECUTABLE)); // Executable areas can't be writable.
+                sections[s].sh_name = dataName;
+                sections[s].sh_flags = SHF_WRITE | SHF_ALLOC;
+                sections[s+1].sh_name = dataRelName; // Name of relocation section
+            }
+            else
+            {
+                // Immutable areas are marked as executable.
+                sections[s].sh_name = textName;
+                sections[s].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+                sections[s+1].sh_name = textRelName; // Name of relocation section
+            }
+            // sections[s].sh_size is set later
+            // sections[s].sh_offset is set later.
+            // sections[s].sh_size is set later.
 
-        // Relocation section
-        sections[s+1].sh_type = useRela ? SHT_RELA : SHT_REL; // Contains relocation with/out explicit addends (ElfXX_Rel)
-        sections[s+1].sh_link = sect_symtab; // Index to symbol table
-        sections[s+1].sh_info = s; // Applies to the data section
-        sections[s+1].sh_addralign = sizeof(long); // Align to a word
-        sections[s+1].sh_entsize = useRela ? sizeof(ElfXX_Rela) : sizeof(ElfXX_Rel);
-        // sections[s+1].sh_offset is set later.
-        // sections[s+1].sh_size is set later.
+            // Relocation section
+            sections[s+1].sh_type = useRela ? SHT_RELA : SHT_REL; // Contains relocation with/out explicit addends (ElfXX_Rel)
+            sections[s+1].sh_link = sect_symtab; // Index to symbol table
+            sections[s+1].sh_info = s; // Applies to the data section
+            sections[s+1].sh_addralign = sizeof(long); // Align to a word
+            sections[s+1].sh_entsize = useRela ? sizeof(ElfXX_Rela) : sizeof(ElfXX_Rel);
+            // sections[s+1].sh_offset is set later.
+            // sections[s+1].sh_size is set later.
+        }
     }
 
     // Table data - Poly tables that describe the memory layout.
-    unsigned sect_table_data = sect_data+2*memTableEntries;
+    unsigned sect_table_data = sect_data + 2*memTableEntries - 1;
 
     sections[sect_table_data].sh_name = dataName;
     sections[sect_table_data].sh_type = SHT_PROGBITS;
@@ -555,12 +567,13 @@ void ELFExport::exportStore(void)
     // Create symbols for the address areas.  AreaToSym assumes these come first.
     for (i = 0; i < memTableEntries; i++)
     {
+        unsigned s = sect_data + i*2 - (i > ioMemEntry ? 1 : 0);
         if (i == ioMemEntry)
-            writeSymbol("ioarea", 0, 0, STB_LOCAL, STT_OBJECT, sect_data+i*2);
+            writeSymbol("ioarea", 0, 0, STB_LOCAL, STT_OBJECT, s);
         else {
             char buff[50];
             sprintf(buff, "area%1u", i);
-            writeSymbol(buff, 0, 0, STB_LOCAL, STT_OBJECT, sect_data+i*2);
+            writeSymbol(buff, 0, 0, STB_LOCAL, STT_OBJECT, s);
         }
     }
 
@@ -569,6 +582,7 @@ void ELFExport::exportStore(void)
     {
         if (i != ioMemEntry)
         {
+            unsigned s = sect_data + i*2 - (i > ioMemEntry ? 1 : 0);
             char buff[50];
             // Write the names of the functions as local symbols.  This isn't necessary
             // but it makes debugging easier since the function names appear in gdb.
@@ -585,7 +599,7 @@ void ELFExport::exportStore(void)
                     // Copy as much of the name as will fit and ignore any extra.
                     // Do we need to worry about duplicates?
                     (void)Poly_string_to_C(*name, buff, sizeof(buff));
-                    writeSymbol(buff, ((char*)p - start), 0, STB_LOCAL, STT_OBJECT, sect_data+i*2);
+                    writeSymbol(buff, ((char*)p - start), 0, STB_LOCAL, STT_OBJECT, s);
                 }
                 p += length;
             }
@@ -604,12 +618,12 @@ void ELFExport::exportStore(void)
 
     for (i = 0; i < memTableEntries; i++)
     {
-        unsigned relocSection = sect_data+i*2+1;
-        alignFile(sections[relocSection].sh_addralign);
-        sections[relocSection].sh_offset = ftell(exportFile);
-        relocationCount = 0;
         if (i != ioMemEntry) // Don't relocate the IO area
         {
+            unsigned relocSection = sect_data + i*2 + 1 - (i > ioMemEntry ? 1 : 0);
+            alignFile(sections[relocSection].sh_addralign);
+            sections[relocSection].sh_offset = ftell(exportFile);
+            relocationCount = 0;
             // Create the relocation table and turn all addresses into offsets.
             char *start = (char*)memTable[i].mtAddr;
             char *end = start + memTable[i].mtLength;
@@ -625,9 +639,9 @@ void ELFExport::exportStore(void)
                 relocateObject(obj);
                 p += length;
             }
+            sections[relocSection].sh_size =
+                relocationCount * (useRela ? sizeof(ElfXX_Rela) : sizeof(ElfXX_Rel));
         }
-        sections[relocSection].sh_size =
-            relocationCount * (useRela ? sizeof(ElfXX_Rela) : sizeof(ElfXX_Rel));
     }
 
     // Relocations for "exports" and "memTable";
@@ -665,11 +679,15 @@ void ELFExport::exportStore(void)
     // Now the binary data.
     for (i = 0; i < memTableEntries; i++)
     {
-        unsigned dataSection = sect_data+i*2;
-        alignFile(sections[dataSection].sh_addralign);
-        sections[dataSection].sh_offset = ftell(exportFile);
+        unsigned dataSection = sect_data + i*2 - (i > ioMemEntry ? 1 : 0);
         sections[dataSection].sh_size = memTable[i].mtLength;
-        fwrite(memTable[i].mtAddr, 1, memTable[i].mtLength, exportFile);
+
+        if (i != ioMemEntry)
+        {
+            alignFile(sections[dataSection].sh_addralign);
+            sections[dataSection].sh_offset = ftell(exportFile);
+            fwrite(memTable[i].mtAddr, 1, memTable[i].mtLength, exportFile);
+        }
     }
 
     exportDescription exports;

--- a/libpolyml/machoexport.cpp
+++ b/libpolyml/machoexport.cpp
@@ -333,7 +333,15 @@ void MachoExport::exportStore(void)
     {
         memset(&(sections[i]), 0, sectionSize);
 
-        if (memTable[i].mtFlags & MTF_WRITEABLE)
+        if (i == ioMemEntry)
+        {
+            ASSERT(memTable[i].mtFlags & MTF_WRITEABLE);
+            ASSERT(!(memTable[i].mtFlags & MTF_EXECUTABLE));
+            sprintf(sections[i].sectname, "__bss");
+            sprintf(sections[i].segname, "__DATA");
+            sections[i].flags = S_ZEROFILL;
+        }
+        else if (memTable[i].mtFlags & MTF_WRITEABLE)
         {
             // Mutable areas
             ASSERT(!(memTable[i].mtFlags & MTF_EXECUTABLE)); // Executable areas can't be writable.
@@ -432,10 +440,10 @@ void MachoExport::exportStore(void)
     // Create and write out the relocations.
     for (i = 0; i < memTableEntries; i++)
     {
-        sections[i].reloff = ftell(exportFile);
-        relocationCount = 0;
         if (i != ioMemEntry) // Don't relocate the IO area
         {
+            sections[i].reloff = ftell(exportFile);
+            relocationCount = 0;
             // Create the relocation table and turn all addresses into offsets.
             char *start = (char*)memTable[i].mtAddr;
             char *end = start + memTable[i].mtLength;
@@ -449,8 +457,8 @@ void MachoExport::exportStore(void)
                 relocateObject(obj);
                 p += length;
             }
+            sections[i].nreloc = relocationCount;
         }
-        sections[i].nreloc = relocationCount;
     }
 
     // Additional relocations for the descriptors.
@@ -511,9 +519,16 @@ void MachoExport::exportStore(void)
     // Now the binary data.
     for (i = 0; i < memTableEntries; i++)
     {
-        alignFile(4);
-        sections[i].offset = ftell(exportFile);
-        fwrite(memTable[i].mtAddr, 1, memTable[i].mtLength, exportFile);
+        if (i == ioMemEntry)
+        {
+            sections[i].offset = 0;
+        }
+        else
+        {
+            alignFile(4);
+            sections[i].offset = ftell(exportFile);
+            fwrite(memTable[i].mtAddr, 1, memTable[i].mtLength, exportFile);
+        }
     }
     // Rewind to rewrite the headers with the actual offsets.
     rewind(exportFile);

--- a/libpolyml/machoexport.cpp
+++ b/libpolyml/machoexport.cpp
@@ -78,7 +78,7 @@
 #include "run_time.h"
 #include "version.h"
 #include "polystring.h"
-
+#include "timing.h"
 
 // Mach-O seems to require each section to have a discrete virtual address range
 // so we have to adjust various offsets to fit.
@@ -491,7 +491,7 @@ void MachoExport::exportStore(void)
     // Set the value to be the offset relative to the base of the area.  We have set a relocation
     // already which will add the base of the area.
     exports.rootFunction = (void*)rootOffset;
-    exports.timeStamp = time(NULL);
+    exports.timeStamp = getBuildTime();
     exports.ioSpacing = ioSpacing;
     exports.architecture = machineDependent->MachineArchitecture();
     exports.rtsVersion = POLY_version_number;

--- a/libpolyml/pecoffexport.cpp
+++ b/libpolyml/pecoffexport.cpp
@@ -56,7 +56,7 @@
 #include "../polyexports.h"
 #include "version.h"
 #include "polystring.h"
-
+#include "timing.h"
 
 #ifdef _DEBUG
 /* MS C defines _DEBUG for debug builds. */
@@ -183,8 +183,7 @@ void PECOFFExport::exportStore(void)
     unsigned i;
     // These are written out as the description of the data.
     exportDescription exports;
-    time_t now;
-    time(&now);
+    time_t now = getBuildTime();
 
     sections = new IMAGE_SECTION_HEADER [memTableEntries+1]; // Plus one for the tables.
 
@@ -197,7 +196,7 @@ void PECOFFExport::exportStore(void)
     fhdr.Machine = IMAGE_FILE_MACHINE_I386; // i386
 #endif
     fhdr.NumberOfSections = memTableEntries+1; // One for each area plus one for the tables.
-    (void)time((time_t*)&fhdr.TimeDateStamp);
+    fhdr.TimeDateStamp = (DWORD)now;
     //fhdr.NumberOfSymbols = memTableEntries+1; // One for each area plus "poly_exports"
     fwrite(&fhdr, sizeof(fhdr), 1, exportFile); // Write it for the moment.
 

--- a/libpolyml/pexport.cpp
+++ b/libpolyml/pexport.cpp
@@ -30,10 +30,6 @@
 #include <stdio.h>
 #endif
 
-#ifdef HAVE_TIME_H
-#include <time.h>
-#endif
-
 #ifdef HAVE_ERRNO_H
 #include <errno.h>
 #endif
@@ -272,8 +268,6 @@ void PExport::ScanConstant(byte *addr, ScanRelocationKind code)
 void PExport::exportStore(void)
 {
     unsigned i;
-    time_t now;
-    time(&now);
 
     // Calculate a first guess for the map size based on the space size
     totalBytes = 0;

--- a/libpolyml/savestate.cpp
+++ b/libpolyml/savestate.cpp
@@ -100,6 +100,7 @@ typedef char TCHAR;
 #include "machine_dep.h"
 #include "osmem.h"
 #include "gc.h" // For FullGC.
+#include "timing.h"
 
 #if(!defined(MAXPATHLEN) && defined(MAX_PATH))
 #define MAXPATHLEN MAX_PATH
@@ -561,7 +562,7 @@ void SaveRequest::Perform()
         saveHeader.parentTimeStamp = hierarchyTable[newHierarchy-2]->timeStamp;
         saveHeader.parentNameEntry = sizeof(TCHAR); // Always the first entry.
     }
-    saveHeader.timeStamp = time(NULL);
+    saveHeader.timeStamp = getBuildTime();
     saveHeader.segmentDescrCount = exports.memTableEntries; // One segment for each space.
     // Write out the header.
     fwrite(&saveHeader, sizeof(saveHeader), 1, exports.exportFile);
@@ -1350,7 +1351,7 @@ void ModuleExport::exportStore(void)
         modHeader.rootSegment = mt->mtIndex;
         modHeader.rootOffset = (char*)this->rootFunction - (char*)mt->mtAddr;
     }
-    modHeader.timeStamp = time(NULL);
+    modHeader.timeStamp = getBuildTime();
     modHeader.segmentDescrCount = this->memTableEntries; // One segment for each space.
     // Write out the header.
     fwrite(&modHeader, sizeof(modHeader), 1, this->exportFile);

--- a/libpolyml/timing.h
+++ b/libpolyml/timing.h
@@ -105,4 +105,6 @@ extern void subTimevals(struct timeval *result, const struct timeval *x);
 extern float timevalToSeconds(const struct timeval *x);
 #endif
 
+extern time_t getBuildTime(void);
+
 #endif


### PR DESCRIPTION
Reproducibility was tested on Debian using [prebuilder](https://anonscm.debian.org/cgit/reproducible/misc.git/tree/prebuilder/?id=420424b096c254aa5610b479fb1746e1a7bd13cb), which performs two builds with different locales, file timestamps and timezones. The resulting binaries were bit-for-bit identical. The ioarea changes have been tested on Windows (native and interpreted x64), OS X and Debian GNU/Linux (native and interpreted amd64; interpreted armhf), which covers all three exporters.