### PR TITLE
Enable Visual Styles for Windows GUI

### DIFF
--- a/PolyML.exe.manifest
+++ b/PolyML.exe.manifest
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assemblyIdentity
+    version="1.0.0.0"
+    processorArchitecture="*"
+    name="PolyML"
+    type="win32"
+/>
+<description>PolyML 5.6</description>
+<dependency>
+    <dependentAssembly>
+        <assemblyIdentity
+            type="win32"
+            name="Microsoft.Windows.Common-Controls"
+            version="6.0.0.0"
+            processorArchitecture="*"
+            publicKeyToken="6595b64144ccf1df"
+            language="*"
+        />
+    </dependentAssembly>
+</dependency>
+</assembly>

--- a/PolyML/PolyML.vcxproj
+++ b/PolyML/PolyML.vcxproj
@@ -177,6 +177,9 @@ $(OutDir)PolyImport.exe -H 32 "%(FullPath)" -o PolyML\$(IntDir)polyexport.obj &l
   <ItemGroup>
     <ResourceCompile Include="..\PolyML.rc" />
   </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="..\PolyML.exe.manifest" />
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{DF3B373E-67DF-4AB4-8B1E-F54C5810E2CF}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>


### PR DESCRIPTION
This makes Windows style the dialog boxes to look modern, rather than using the old plain grey look.