### PR TITLE
Remove all use of MAXPATHLEN and its variants

### DIFF
--- a/libpolyml/basicio.cpp
+++ b/libpolyml/basicio.cpp
@@ -111,10 +111,6 @@ typedef char TCHAR;
 #define _tcsdup strdup
 #endif
 
-#if(!defined(MAXPATHLEN) && defined(MAX_PATH))
-#define MAXPATHLEN MAX_PATH
-#endif
-
 #ifndef O_BINARY
 #define O_BINARY    0 /* Not relevant. */
 #endif
@@ -1651,13 +1647,21 @@ Handle IO_dispatch_c(TaskData *taskData, Handle args, Handle strm, Handle code)
                 raise_syscall(taskData, "GetCurrentDirectory failed", -(int)GetLastError());
             return SAVE(C_string_to_Poly(taskData, buff));
 #else
-            // This is a bit messy in Unix.  getcwd will return an error result if there's
-            // not enough space be we have to iterate to find the size.
-            // Use the fixed size for the moment.
-            TCHAR string_buffer[MAXPATHLEN+1];
-            if (getcwd(string_buffer, MAXPATHLEN+1) == NULL)
+            size_t size = 4096;
+            TempString string_buffer((TCHAR *)malloc(size * sizeof(TCHAR)));
+            if (string_buffer == NULL) raise_syscall(taskData, "Insufficient memory", ENOMEM);
+            TCHAR *cwd;
+            while ((cwd = getcwd(string_buffer, size)) == NULL && errno == ERANGE) {
+                if (size > SIZE_MAX / 2) raise_fail(taskData, "getcwd needs too large a buffer");
+                size *= 2;
+                TCHAR *new_buf = (TCHAR *)realloc(string_buffer, size * sizeof(TCHAR));
+                if (new_buf == NULL) raise_syscall(taskData, "Insufficient memory", ENOMEM);
+                string_buffer = new_buf;
+            }
+
+            if (cwd == NULL)
                raise_syscall(taskData, "getcwd failed", errno);
-            return SAVE(C_string_to_Poly(taskData, string_buffer));
+            return SAVE(C_string_to_Poly(taskData, cwd));
 #endif
         }
 
@@ -1728,8 +1732,19 @@ Handle IO_dispatch_c(TaskData *taskData, Handle args, Handle strm, Handle code)
             int nLen;
             TempString linkName(args->Word());
             if (linkName == 0) raise_syscall(taskData, "Insufficient memory", ENOMEM);
-            char resBuf[MAXPATHLEN];
-            nLen = readlink(linkName, resBuf, sizeof(resBuf));
+
+            size_t size = 4096;
+            TempString resBuf((TCHAR *)malloc(size * sizeof(TCHAR)));
+            if (resBuf == NULL) raise_syscall(taskData, "Insufficient memory", ENOMEM);
+            // nLen is signed, so cast size to ssize_t to perform signed
+            // comparison, avoiding an infinite loop when nLen is -1.
+            while ((nLen = readlink(linkName, resBuf, size)) >= (ssize_t) size) {
+                size *= 2;
+                if (size > SSIZE_MAX) raise_fail(taskData, "readlink needs too large a buffer");
+                TCHAR *newBuf = (TCHAR *)realloc(resBuf, size * sizeof(TCHAR));
+                if (newBuf == NULL) raise_syscall(taskData, "Insufficient memory", ENOMEM);
+                resBuf = newBuf;
+            }
             if (nLen < 0) raise_syscall(taskData, "readlink failed", errno);
             return(SAVE(C_string_to_Poly(taskData, resBuf, nLen)));
 #endif
@@ -1780,13 +1795,18 @@ Handle IO_dispatch_c(TaskData *taskData, Handle args, Handle strm, Handle code)
                 raise_syscall(taskData, "GetTempPath failed", -(int)(GetLastError()));
             lstrcat(buff, _T("MLTEMPXXXXXX"));
 #else
-            TCHAR buff[MAXPATHLEN];
+            const char *template_subdir =  "/MLTEMPXXXXXX";
 #ifdef P_tmpdir
+            TempString buff((TCHAR *)malloc(strlen(P_tmpdir) + strlen(template_subdir) + 1));
+            if (buff == 0) raise_syscall(taskData, "Insufficient memory", ENOMEM);
             strcpy(buff, P_tmpdir);
 #else
-            strcpy(buff, "/tmp");
+            const char *tmpdir = "/tmp";
+            TempString buff((TCHAR *)malloc(strlen(tmpdir) + strlen(template_subdir) + 1));
+            if (buff == 0) raise_syscall(taskData, "Insufficient memory", ENOMEM);
+            strcpy(buff, tmpdir);
 #endif
-            strcat(buff, "/MLTEMPXXXXXX");
+            strcat(buff, template_subdir);
 #endif
 
 #if (defined(HAVE_MKSTEMP) && ! defined(UNICODE))

--- a/libpolyml/exporter.cpp
+++ b/libpolyml/exporter.cpp
@@ -82,10 +82,6 @@
 #include "machoexport.h"
 #endif
 
-#if(!defined(MAXPATHLEN) && defined(MAX_PATH))
-#define MAXPATHLEN MAX_PATH
-#endif
-
 /*
 To export the function and everything reachable from it we need to copy
 all the objects into a new area.  We leave tombstones in the original
@@ -416,14 +412,14 @@ public:
 
 static void exporter(TaskData *taskData, Handle args, const TCHAR *extension, Exporter *exports)
 {
-    TCHAR fileNameBuff[MAXPATHLEN+MAX_EXTENSION];
-    POLYUNSIGNED length =
-        Poly_string_to_C(DEREFHANDLE(args)->Get(0), fileNameBuff, MAXPATHLEN);
-    if (length > MAXPATHLEN)
-        raise_syscall(taskData, "File name too long", ENAMETOOLONG);
+    size_t extLen = _tcslen(extension);
+    TempString fileNameBuff(Poly_string_to_C_alloc(DEREFHANDLE(args)->Get(0), extLen * sizeof(TCHAR)));
+    if (fileNameBuff == NULL)
+        raise_syscall(taskData, "Insufficient memory", ENOMEM);
+    size_t length = _tcslen(fileNameBuff);
 
     // Does it already have the extension?  If not add it on.
-    if (length < _tcslen(extension) || _tcscmp(fileNameBuff + length - _tcslen(extension), extension) != 0)
+    if (length < extLen || _tcscmp(fileNameBuff + length - extLen, extension) != 0)
         _tcscat(fileNameBuff, extension);
 #if (defined(_WIN32) && defined(UNICODE))
     exports->exportFile = _wfopen(fileNameBuff, L"wb");

--- a/libpolyml/polystring.cpp
+++ b/libpolyml/polystring.cpp
@@ -97,7 +97,7 @@ POLYUNSIGNED Poly_string_to_C(PolyWord ps, char *buff, POLYUNSIGNED bufflen)
     return chars;
 } /* Poly_string_to_C */
 
-char *Poly_string_to_C_alloc(PolyWord ps)
+char *Poly_string_to_C_alloc(PolyWord ps, size_t buffExtra)
 /* Similar to Poly_string_to_C except that the string is allocated using
    malloc and must be freed by the caller. */
 {
@@ -105,7 +105,7 @@ char *Poly_string_to_C_alloc(PolyWord ps)
 
     if (IS_INT(ps))
     {
-        res = (char*)malloc(2);
+        res = (char*)malloc(2 + buffExtra);
         if (res == 0) return 0;
         res[0] = (char)(UNTAGGED(ps));
         res[1] = '\0';
@@ -114,7 +114,7 @@ char *Poly_string_to_C_alloc(PolyWord ps)
     {
         PolyStringObject * str = (PolyStringObject *)ps.AsObjPtr();
         POLYUNSIGNED chars = str->length;
-        res = (char*)malloc(chars+1);
+        res = (char*)malloc(chars + buffExtra + 1);
         if (res == 0) return 0;
         if (chars != 0) strncpy(res, str->chars, chars);
         res[chars] = '\0';

--- a/libpolyml/polystring.h
+++ b/libpolyml/polystring.h
@@ -46,7 +46,7 @@ extern PolyWord EmptyString(void);
 /* PolyStringObject functions */
 extern PolyWord C_string_to_Poly(TaskData *mdTaskData, const char *buffer, size_t buffLen = -1);
 extern POLYUNSIGNED Poly_string_to_C(PolyWord ps, char *buff, POLYUNSIGNED bufflen);
-extern char *Poly_string_to_C_alloc(PolyWord ps);
+extern char *Poly_string_to_C_alloc(PolyWord ps, size_t buffExtra = 0);
 
 extern Handle convert_string_list(TaskData *mdTaskData, int count, char **strings);
 

--- a/libpolyml/savestate.cpp
+++ b/libpolyml/savestate.cpp
@@ -102,10 +102,6 @@ typedef char TCHAR;
 #include "gc.h" // For FullGC.
 #include "timing.h"
 
-#if(!defined(MAXPATHLEN) && defined(MAX_PATH))
-#define MAXPATHLEN MAX_PATH
-#endif
-
 #ifdef _MSC_VER
 // Don't tell me about ISO C++ changes.
 #pragma warning(disable:4996)
@@ -652,11 +648,7 @@ void SaveRequest::Perform()
 
 Handle SaveState(TaskData *taskData, Handle args)
 {
-    TCHAR fileNameBuff[MAXPATHLEN];
-    POLYUNSIGNED length =
-        Poly_string_to_C(DEREFHANDLE(args)->Get(0), fileNameBuff, MAXPATHLEN);
-    if (length > MAXPATHLEN)
-        raise_syscall(taskData, "File name too long", ENAMETOOLONG);
+    TempString fileNameBuff(Poly_string_to_C_alloc(DEREFHANDLE(args)->Get(0)));
     // The value of depth is zero for top-level save so we need to add one for hierarchy.
     unsigned newHierarchy = get_C_unsigned(taskData, DEREFHANDLE(args)->Get(1)) + 1;
 
@@ -693,7 +685,7 @@ public:
     // The fileName here is the last file loaded.  As well as using it
     // to load the name can also be printed out at the end to identify the
     // particular file in the hierarchy that failed.
-    TCHAR fileName[MAXPATHLEN];
+    AutoFree<TCHAR*> fileName;
     int errNumber;
 };
 
@@ -709,23 +701,22 @@ void StateLoader::Perform(void)
             return;
         }
         ML_Cons_Cell *p = DEREFLISTHANDLE(fileNameList);
-        POLYUNSIGNED length = Poly_string_to_C(p->h, fileName, MAXPATHLEN);
-        if (length > MAXPATHLEN)
+        fileName = Poly_string_to_C_alloc(p->h);
+        if (fileName == NULL)
         {
-            errorResult = "File name too long";
-            errNumber = ENAMETOOLONG;
+            errorResult = "Insufficient memory";
+            errNumber = ENOMEM;
             return;
         }
         (void)LoadFile(true, 0, p->t);
     }
     else
     {
-        POLYUNSIGNED length =
-            Poly_string_to_C(DEREFHANDLE(fileNameList), fileName, MAXPATHLEN);
-        if (length > MAXPATHLEN)
+        fileName = Poly_string_to_C_alloc(DEREFHANDLE(fileNameList));
+        if (fileName == NULL)
         {
-            errorResult = "File name too long";
-            errNumber = ENAMETOOLONG;
+            errorResult = "Insufficient memory";
+            errNumber = ENOMEM;
             return;
         }
         (void)LoadFile(true, 0, TAGGED(0));
@@ -866,11 +857,11 @@ bool StateLoader::LoadFile(bool isInitial, time_t requiredStamp, PolyWord tail)
                 return false;
             }
             ML_Cons_Cell *p = (ML_Cons_Cell *)tail.AsObjPtr();
-            POLYUNSIGNED length = Poly_string_to_C(p->h, fileName, MAXPATHLEN);
-            if (length > MAXPATHLEN)
+            fileName = Poly_string_to_C_alloc(p->h);
+            if (fileName == NULL)
             {
-                errorResult = "File name too long";
-                errNumber = ENAMETOOLONG;
+                errorResult = "Insufficient memory";
+                errNumber = ENOMEM;
                 return false;
             }
             if (! LoadFile(false, header.parentTimeStamp, p->t))
@@ -879,7 +870,17 @@ bool StateLoader::LoadFile(bool isInitial, time_t requiredStamp, PolyWord tail)
         else
         {
             size_t toRead = header.stringTableSize-header.parentNameEntry;
-            if (MAXPATHLEN < toRead) toRead = MAXPATHLEN;
+            size_t elems = ((toRead + sizeof(TCHAR) - 1) / sizeof(TCHAR));
+            // Always allow space for null terminator
+            size_t roundedBytes = (elems + 1) * sizeof(TCHAR);
+            TCHAR *newFileName = (TCHAR *)realloc(fileName, roundedBytes);
+            if (newFileName == NULL)
+            {
+                errorResult = "Insufficient memory";
+                errNumber = ENOMEM;
+                return false;
+            }
+            fileName = newFileName;
 
             if (header.parentNameEntry >= header.stringTableSize /* Bad entry */ ||
                 fseek(loadFile, header.stringTable + header.parentNameEntry, SEEK_SET) != 0 ||
@@ -888,7 +889,7 @@ bool StateLoader::LoadFile(bool isInitial, time_t requiredStamp, PolyWord tail)
                 errorResult = "Unable to read parent file name";
                 return false;
             }
-            fileName[toRead] = 0; // Should already be null-terminated, but just in case.
+            fileName[elems] = 0; // Should already be null-terminated, but just in case.
 
             if (! LoadFile(false, header.parentTimeStamp, TAGGED(0)))
                 return false;
@@ -1096,11 +1097,11 @@ Handle LoadState(TaskData *taskData, bool isHierarchy, Handle hFileList)
             raise_fail(taskData, loader.errorResult);
         else
         {
-            char buff[MAXPATHLEN+100];
+            AutoFree<char*> buff((char *)malloc(strlen(loader.errorResult) + 2 + _tcslen(loader.fileName) * sizeof(TCHAR) + 1));
 #if (defined(_WIN32) && defined(UNICODE))
-            sprintf(buff, "%s: %S", loader.errorResult, loader.fileName);
+            sprintf(buff, "%s: %S", loader.errorResult, (TCHAR *)loader.fileName);
 #else
-            sprintf(buff, "%s: %s", loader.errorResult, loader.fileName);
+            sprintf(buff, "%s: %s", loader.errorResult, (TCHAR *)loader.fileName);
 #endif
             raise_syscall(taskData, buff, loader.errNumber);
         }
@@ -1138,26 +1139,23 @@ Handle ShowHierarchy(TaskData *taskData)
 Handle RenameParent(TaskData *taskData, Handle args)
 // Change the name of the immediate parent stored in a child
 {
-    TCHAR fileNameBuff[MAXPATHLEN], parentNameBuff[MAXPATHLEN];
     // The name of the file to modify.
-    POLYUNSIGNED fileLength =
-        Poly_string_to_C(DEREFHANDLE(args)->Get(0), fileNameBuff, MAXPATHLEN);
-    if (fileLength > MAXPATHLEN)
-        raise_syscall(taskData, "File name too long", ENAMETOOLONG);
+    AutoFree<TCHAR*> fileNameBuff(Poly_string_to_C_alloc(DEREFHANDLE(args)->Get(0)));
+    if (fileNameBuff == NULL)
+        raise_syscall(taskData, "Insufficient memory", ENOMEM);
     // The new parent name to insert.
-    POLYUNSIGNED parentLength =
-        Poly_string_to_C(DEREFHANDLE(args)->Get(1), parentNameBuff, MAXPATHLEN);
-    if (parentLength > MAXPATHLEN)
-        raise_syscall(taskData, "Parent name too long", ENAMETOOLONG);
+    AutoFree<TCHAR*> parentNameBuff(Poly_string_to_C_alloc(DEREFHANDLE(args)->Get(1)));
+    if (parentNameBuff == NULL)
+        raise_syscall(taskData, "Insufficient memory", ENOMEM);
 
     AutoClose loadFile(_tfopen(fileNameBuff, _T("r+b"))); // Open for reading and writing
     if ((FILE*)loadFile == NULL)
     {
-        char buff[MAXPATHLEN+1+23];
+        AutoFree<char*> buff((char *)malloc(23 + _tcslen(fileNameBuff) * sizeof(TCHAR) + 1));
 #if (defined(_WIN32) && defined(UNICODE))
-        sprintf(buff, "Cannot open load file: %S", fileNameBuff);
+        sprintf(buff, "Cannot open load file: %S", (TCHAR *)fileNameBuff);
 #else
-        sprintf(buff, "Cannot open load file: %s", fileNameBuff);
+        sprintf(buff, "Cannot open load file: %s", (TCHAR *)fileNameBuff);
 #endif
         raise_syscall(taskData, buff, errno);
     }
@@ -1202,20 +1200,18 @@ Handle RenameParent(TaskData *taskData, Handle args)
 Handle ShowParent(TaskData *taskData, Handle hFileName)
 // Return the name of the immediate parent stored in a child
 {
-    TCHAR fileNameBuff[MAXPATHLEN+1];
-    POLYUNSIGNED length =
-        Poly_string_to_C(DEREFHANDLE(hFileName), fileNameBuff, MAXPATHLEN);
-    if (length > MAXPATHLEN)
-        raise_syscall(taskData, "File name too long", ENAMETOOLONG);
+    AutoFree<TCHAR*> fileNameBuff(Poly_string_to_C_alloc(DEREFHANDLE(hFileName)));
+    if (fileNameBuff == NULL)
+        raise_syscall(taskData, "Insufficient memory", ENOMEM);
 
     AutoClose loadFile(_tfopen(fileNameBuff, _T("rb")));
     if ((FILE*)loadFile == NULL)
     {
-        char buff[MAXPATHLEN+1+23];
+        AutoFree<char*> buff((char *)malloc(23 + _tcslen(fileNameBuff) * sizeof(TCHAR) + 1));
 #if (defined(_WIN32) && defined(UNICODE))
-        sprintf(buff, "Cannot open load file: %S", fileNameBuff);
+        sprintf(buff, "Cannot open load file: %S", (TCHAR *)fileNameBuff);
 #else
-        sprintf(buff, "Cannot open load file: %s", fileNameBuff);
+        sprintf(buff, "Cannot open load file: %s", (TCHAR *)fileNameBuff);
 #endif
         raise_syscall(taskData, buff, errno);
     }
@@ -1238,9 +1234,13 @@ Handle ShowParent(TaskData *taskData, Handle hFileName)
     // Does this have a parent?
     if (header.parentNameEntry != 0)
     {
-        TCHAR parentFileName[MAXPATHLEN+1];
         size_t toRead = header.stringTableSize-header.parentNameEntry;
-        if (MAXPATHLEN < toRead) toRead = MAXPATHLEN;
+        size_t elems = ((toRead + sizeof(TCHAR) - 1) / sizeof(TCHAR));
+        // Always allow space for null terminator
+        size_t roundedBytes = (elems + 1) * sizeof(TCHAR);
+        AutoFree<TCHAR*> parentFileName((TCHAR *)malloc(roundedBytes));
+        if (parentFileName == NULL)
+            raise_syscall(taskData, "Insufficient memory", ENOMEM);
 
         if (header.parentNameEntry >= header.stringTableSize /* Bad entry */ ||
             fseek(loadFile, header.stringTable + header.parentNameEntry, SEEK_SET) != 0 ||
@@ -1248,7 +1248,7 @@ Handle ShowParent(TaskData *taskData, Handle hFileName)
         {
             raise_fail(taskData, "Unable to read parent file name");
         }
-        parentFileName[toRead] = 0; // Should already be null-terminated, but just in case.
+        parentFileName[elems] = 0; // Should already be null-terminated, but just in case.
         // Convert the name into a Poly string and then build a "Some" value.
         // It's possible, although silly, to have the empty string as a parent name.
         Handle resVal = SAVE(C_string_to_Poly(taskData, parentFileName));
@@ -1602,7 +1602,7 @@ Handle LoadModule(TaskData *taskData, Handle args)
             raise_fail(taskData, loader.errorResult);
         else
         {
-            char buff[MAXPATHLEN+100];
+            AutoFree<char*> buff((char *)malloc(strlen(loader.errorResult) + 2 + _tcslen(loader.fileName) * sizeof(TCHAR) + 1));
 #if (defined(_WIN32) && defined(UNICODE))
             sprintf(buff, "%s: %S", loader.errorResult, loader.fileName);
 #else


### PR DESCRIPTION
Systems are not required to define PATH_MAX/MAXPATHLEN if there is no limit, and in fact the Hurd does not define PATH_MAX/MAXPATHLEN; by removing all of these uses, it now builds on the Hurd.