### PR TITLE
Mark stack as non-executable on all GNU systems

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -129,6 +129,9 @@
 /* Define to 1 if you have the `gmtime_r' function. */
 #undef HAVE_GMTIME_R
 
+/* Define to 1 if you have .note.GNU-stack support in the assembler. */
+#undef HAVE_GNU_STACK
+
 /* Define to 1 if you have the <grp.h> header file. */
 #undef HAVE_GRP_H
 

--- a/configure.ac
+++ b/configure.ac
@@ -401,6 +401,13 @@ AC_CHECK_MEMBERS([struct sockaddr_un.sun_len],,,
 # Additional checks. AC_CANONICAL_HOST has already been called.
 #AC_CANONICAL_HOST
 
+# Check for .note.GNU-stack support, used for marking the stack as non-executable.
+AC_MSG_CHECKING([whether as supports .note.GNU-stack])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[__asm__(".section .note.GNU-stack,\"\",@progbits");]])],
+    [AC_MSG_RESULT([yes])] [AC_DEFINE([HAVE_GNU_STACK], [1],
+        [Define to 1 if you have .note.GNU-stack support in the assembler.])],
+    [AC_MSG_RESULT([no])])
+
 # This option enables the native code generator.  More precisely it allows
 # the byte code interpreter to be built on X86.
 

--- a/libpolyml/x86asm.asm
+++ b/libpolyml/x86asm.asm
@@ -791,11 +791,9 @@ ENDIF
 
 ENDIF
 
-;# Mark the stack as non-executable when compiling for Linux
-IFDEF __linux__
-IFDEF __ELF__
+;# Mark the stack as non-executable when supported
+IFDEF HAVE_GNU_STACK
 .section .note.GNU-stack, "", @progbits
-ENDIF
 ENDIF
 
 ;#


### PR DESCRIPTION
This allows the stack to be marked as non-executable on the Hurd and Debian GNU/kFreeBSD.