### PR TITLE
Add support for x32 ABI

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -590,6 +590,9 @@
 /* Define if the host is a Sparc (32-bit) */
 #undef HOSTARCHITECTURE_SPARC
 
+/* Define if the host is an X86 (32-bit ABI, 64-bit processor) */
+#undef HOSTARCHITECTURE_X32
+
 /* Define if the host is an X86 (32-bit) */
 #undef HOSTARCHITECTURE_X86
 

--- a/configure.ac
+++ b/configure.ac
@@ -420,8 +420,13 @@ case "${host_cpu}" in
             polyarch=i386
             ;;
       x86_64* | amd64*)
-            AC_DEFINE([HOSTARCHITECTURE_X86_64], [1], [Define if the host is an X86 (64-bit)])
-            polyarch=x86_64
+            if test X"$ac_cv_sizeof_voidp" = X8; then
+                AC_DEFINE([HOSTARCHITECTURE_X86_64], [1], [Define if the host is an X86 (64-bit)])
+                polyarch=x86_64
+            else
+                AC_DEFINE([HOSTARCHITECTURE_X32], [1], [Define if the host is an X86 (32-bit ABI, 64-bit processor)])
+                polyarch=interpret
+            fi
             ;;
       sparc*)
             AC_DEFINE([HOSTARCHITECTURE_SPARC], [1], [Define if the host is a Sparc (32-bit)])

--- a/libpolyml/elfexport.cpp
+++ b/libpolyml/elfexport.cpp
@@ -221,7 +221,8 @@ void ELFExport::ScanConstant(byte *addr, ScanRelocationKind code)
             }
         }
         break;
-#if(defined(HOSTARCHITECTURE_X86) || defined(HOSTARCHITECTURE_X86_64))
+#if(defined(HOSTARCHITECTURE_X86) || defined(HOSTARCHITECTURE_X86_64) || \
+        defined(HOSTARCHITECTURE_X32))
 #ifdef HOSTARCHITECTURE_X86
 #define R_PC_RELATIVE R_386_PC32
 #else
@@ -401,6 +402,10 @@ void ELFExport::exportStore(void)
        Linux will support either so we now use Rela on X86-64. */
     fhdr.e_machine = EM_X86_64;
     directReloc = R_X86_64_64;
+    useRela = true;
+#elif defined(HOSTARCHITECTURE_X32)
+    fhdr.e_machine = EM_X86_64;
+    directReloc = R_X86_64_32;
     useRela = true;
 #elif defined(HOSTARCHITECTURE_ARM)
 #ifndef EF_ARM_EABI_VER4 

--- a/libpolyml/quick_gc.cpp
+++ b/libpolyml/quick_gc.cpp
@@ -137,7 +137,7 @@ static bool atomiclySetForwarding(LocalMemSpace *space, POLYUNSIGNED *pt,
     POLYUNSIGNED result = InterlockedCompareExchange(address, update, testVal);
     return result == testVal;
 # endif
-#elif(defined(HOSTARCHITECTURE_X86) && defined(__GNUC__))
+#elif((defined(HOSTARCHITECTURE_X86) || defined(HOSTARCHITECTURE_X32)) && defined(__GNUC__))
     POLYUNSIGNED result;
     __asm__ __volatile__ (
         "lock; cmpxchgl %1,%2"

--- a/libpolyml/realconv.cpp
+++ b/libpolyml/realconv.cpp
@@ -220,7 +220,8 @@
 
 #if !defined(IEEE_8087) && ! defined(IEEE_MC68k)
 #if defined(_WIN32) || defined(HOSTARCHITECTURE_X86) || defined (__i386__) || defined (_M_IX86) || \
-        defined (vax) || defined (__alpha) || defined(HOSTARCHITECTURE_X86_64)
+        defined (vax) || defined (__alpha) || defined(HOSTARCHITECTURE_X86_64) || \
+        defined(HOSTARCHITECTURE_X32)
 #define IEEE_8087
 #else
 #define IEEE_MC68k


### PR DESCRIPTION
This is a 32-bit ABI for amd64, allowing the compiler to use the extended set of registers on an amd64 processor, whilst using 32-bit pointers and words for reduced memory usage. Currently only the interpreted version is supported.