### PR TITLE
Adds support for unicode string literals in lexer

### DIFF
--- a/mlsource/MLCompiler/LEX_.ML
+++ b/mlsource/MLCompiler/LEX_.ML
@@ -387,13 +387,9 @@ struct
                     (
                      nextCh state;
                      if ch = eofChar then raise EndOfLine
-                     else if Char.isPrint ch (* Ok if it's printable. *)
+                     else if Char.isPrint ch
                      then getString (ch :: soFar)
-                     else (* Report unprintable characters. *)
-                        (
-                        lexError(state, "unprintable character " ^ Char.toString ch ^ " found in string");
-                        getString soFar
-                        )
+                     else getString (List.rev (String.explode (Char.toString ch)) @ soFar)
                     )
          )
 


### PR DESCRIPTION
Here is a potential fix to deal with the following:

```
> print "한";
Error-unprintable character \237 found in string
Error-unprintable character \149 found in string
Error-unprintable character \156 found in string
Static Errors
> print "\237\149\156";
한val it = (): unit
```

I am not sure why it's necessary for the first case to be wrong but the second case to be accepted. This method converts the characters in the first version to a string of those characters as in the second version.

What do you think?