### PR TITLE
Cast NOFLSH to unsigned

### DIFF
--- a/libpolyml/unix_specific.cpp
+++ b/libpolyml/unix_specific.cpp
@@ -288,7 +288,7 @@ static unsigned unixConstVec[] =
     ICANON,
     IEXTEN,
     ISIG,
-    NOFLSH,
+    (unsigned)NOFLSH,
     TOSTOP, /* 115 */
 
     /* TTY: Speeds. */


### PR DESCRIPTION
On some platforms, such as the Hurd, NOFLSH is `1 << 31`. If the system is 32-bit (like the Hurd currently), this is a negative signed value (as 1 is a signed constant).