### PR TITLE
update doc with correct function ref.

### DIFF
--- a/documentation/Reference/PolyMLMake.html
+++ b/documentation/Reference/PolyMLMake.html
@@ -28,7 +28,7 @@ consistent with respect to the modules it uses.</font></p>
   to remake that object from its source code.</font></p>
 
 <p><font SIZE="3">The make system assumes that source code for functors, structures and
-signatures is kept in files whose names resemble those of the objects. The variable </font><b><font FACE="Courier" SIZE="3">PolyML.Compiler.suffixes</font></b><font SIZE="3"> contains the
+signatures is kept in files whose names resemble those of the objects. The variable </font><b><font FACE="Courier" SIZE="3">PolyML.suffixes</font></b><font SIZE="3"> contains the
 list of filename suffixes recognised by the make system, in the order that the system
 tries them. The default list is </font><font FACE="Courier" SIZE="3"><b>[&quot;&quot;,
 &quot;.ML&quot;, &quot;.sml&quot;]</b></font><font SIZE="3">.</font></p>


### PR DESCRIPTION
`suffixes` function has moved to PolyML structure rather than the Compiler. Updated doc.