### PR TITLE
Add support for SuperH

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -590,6 +590,9 @@
 /* Define if the host is an S/390 (64-bit) */
 #undef HOSTARCHITECTURE_S390X
 
+/* Define if the host is a SuperH (32-bit) */
+#undef HOSTARCHITECTURE_SH
+
 /* Define if the host is a Sparc (32-bit) */
 #undef HOSTARCHITECTURE_SPARC
 

--- a/configure.ac
+++ b/configure.ac
@@ -479,6 +479,10 @@ case "${host_cpu}" in
             AC_DEFINE([HOSTARCHITECTURE_S390], [1], [Define if the host is an S/390 (32-bit)])
             polyarch=interpret
             ;;
+      sh*)
+            AC_DEFINE([HOSTARCHITECTURE_SH], [1], [Define if the host is a SuperH (32-bit)])
+            polyarch=interpret
+            ;;
       alpha*)
             AC_DEFINE([HOSTARCHITECTURE_ALPHA], [1], [Define if the host is an Alpha (64-bit)])
             polyarch=interpret

--- a/libpolyml/elfexport.cpp
+++ b/libpolyml/elfexport.cpp
@@ -389,6 +389,10 @@ void ELFExport::exportStore(void)
     fhdr.e_machine = EM_S390;
     directReloc = R_390_64;
     useRela = true;
+#elif defined(HOSTARCHITECTURE_SH)
+    fhdr.e_machine = EM_SH;
+    directReloc = R_SH_DIR32;
+    useRela = true;
 #elif defined(HOSTARCHITECTURE_SPARC)
     fhdr.e_machine = EM_SPARC;
     directReloc = R_SPARC_32;


### PR DESCRIPTION
Passes the test suite. SuperH only has two rounding modes, `FE_TONEAREST` and `FE_TOWARDZERO`, with `FE_UPWARD` and `FE_DOWNWARD` not defined.