### PR TITLE
libpolyml: Bail out when file operations fail during state loading.

### DIFF
--- a/libpolyml/savestate.cpp
+++ b/libpolyml/savestate.cpp
@@ -1049,6 +1049,7 @@ bool StateLoader::LoadFile(bool isInitial, time_t requiredStamp, PolyWord tail)
             if (fseek(loadFile, descr->relocations, SEEK_SET) != 0)
             {
                 errorResult = "Unable to read relocation segment";
+                return false;
             }
             for (unsigned k = 0; k < descr->relocationCount; k++)
             {
@@ -1056,6 +1057,7 @@ bool StateLoader::LoadFile(bool isInitial, time_t requiredStamp, PolyWord tail)
                 if (fread(&reloc, sizeof(reloc), 1, loadFile) != 1)
                 {
                     errorResult = "Unable to read relocation segment";
+                    return false;
                 }
                 MemSpace *toSpace =
                     reloc.targetSegment == 0 ? gMem.IoSpace() : gMem.SpaceForIndex(reloc.targetSegment);


### PR DESCRIPTION
This commit modifies the state loading logic to return when file operations
fail while processing relocations. The rationale is that, while it may make
sense to continue when a relocation entry is corrupted, is does not make sense
to continue when an fread or fseek fails as we end up incorrectly interpreting
data.