### PR TITLE
Make MainThreadRequest completed field volatile

### DIFF
--- a/libpolyml/processes.h
+++ b/libpolyml/processes.h
@@ -225,7 +225,7 @@ public:
     MainThreadRequest (enum _mainThreadPhase phase): mtp(phase), completed(false) {}
     virtual ~MainThreadRequest () {} // Suppress silly GCC warning
     const enum _mainThreadPhase mtp;
-    bool completed;
+    volatile bool completed;
     virtual void Perform() = 0;
 };
 


### PR DESCRIPTION
This is accessed across threads and thus needs to be volatile in order to avoid compiler optimisations breaking memory access order. This fixes Tests/Succeed/Test120.ML sometimes deadlocking on HP PA-RISC.