### PR TITLE
Fix threadExited and interrupt_requested overlapping

### DIFF
--- a/libpolyml/processes.h
+++ b/libpolyml/processes.h
@@ -172,7 +172,7 @@ private:
 #ifdef HAVE_WINDOWS_H
     LONGLONG lastCPUTime; // Used for profiling
 #endif
-#ifdef HAVE_PTHREAD
+#if ((!defined(_WIN32) || defined(__CYGWIN__)) && defined(HAVE_LIBPTHREAD) && defined(HAVE_PTHREAD_H))
 public:
     bool threadExited;
 private:


### PR DESCRIPTION
HAVE_PTHREAD isn't necessarily defined when processes.h is included, as it is defined in processes.cpp, but not when included by interpret.cpp.  As a result, the root thread can believe that an interrupted thread has been killed, prematurely deleting its task data. This fixes #9.