### PR TITLE
Fix get_arbitrary_precision_as_real with GMP on big-endian systems

### DIFF
--- a/libpolyml/arb.cpp
+++ b/libpolyml/arb.cpp
@@ -1493,12 +1493,24 @@ double get_arbitrary_precision_as_real(TaskData *, PolyWord x)
         POLYSIGNED t = UNTAGGED(x);
         return (double)t;
     }
+    double acc = 0;
+#if USE_GMP
+    mp_limb_t *u = (mp_limb_t *)(x.AsObjPtr());
+    mp_size_t lx = numLimbs(x);
+    for ( ; lx > 0; lx--) {
+        int ll = sizeof(mp_limb_t);
+        for ( ; ll > 0 ; ll-- ) {
+            acc = acc * 256;
+        }
+        acc = acc + (double)u[lx-1];
+    }
+#else
     byte *u = (byte *)(x.AsObjPtr());
     POLYUNSIGNED lx = OBJECT_LENGTH(x)*sizeof(PolyWord);
-    double acc = 0;
     for( ; lx > 0; lx--) {
         acc = acc * 256 + (double)u[lx-1];
     }
+#endif
     if (OBJ_IS_NEGATIVE(GetLengthWord(x)))
         return -acc;
     else return acc;


### PR DESCRIPTION
This caused Tests/Succeed/Test101.ML to fail on big-endian systems if compiled with GMP support, as the limbs are stored in little-endian order, but not the bytes within the limbs themselves. I'm also slightly wary of logical_long, as it uses byte arrays and does two's complement in places, so that might need checking as well (and a test case, of course, if it turns out to be broken!).