### PR TITLE
fix compile errors when cross-compiling under Linux for Windows using…

### DIFF
--- a/libpolyml/Console.cpp
+++ b/libpolyml/Console.cpp
@@ -64,7 +64,7 @@
 #include "mpoly.h"
 #include "run_time.h"
 #include "sighandler.h"
-#include "console.h"
+#include "Console.h"
 #include "../polyexports.h"
 #include "processes.h"
 #include "polystring.h"

--- a/polyexports.h
+++ b/polyexports.h
@@ -82,7 +82,7 @@ extern "C" {
 #endif
 
 #if (defined(_WIN32) && ! defined(__CYGWIN__))
-#include <Windows.h>
+#include <windows.h>
 
 # ifdef LIBPOLYML_BUILD
 #  ifdef DLL_EXPORT


### PR DESCRIPTION
… mingw

This changes a few header includes so they use the 'case sensitive' file name
rather than the 'case insensitive' file name. This should work for both Linux
and Windows hosts now when compiling Poly/ML.