### PR TITLE
Optimise a loop in Bitmap::SetBits.

### DIFF
--- a/libpolyml/bitmap.cpp
+++ b/libpolyml/bitmap.cpp
@@ -108,14 +108,11 @@ void Bitmap::SetBits(POLYUNSIGNED bitno, POLYUNSIGNED length)
     }
     
     /* Set as many full bytes as possible */
-    while (8 <= length)
+    if (8 <= length)
     {
-        /* Invariant: 8 <= length */
-        byte_index ++;
-//        ASSERT(m_bits[byte_index] == 0);
-        m_bits[byte_index] = 0xff;
-        length -= 8;
-        /* Invariant: 0 <= length */
+        memset(m_bits + byte_index + 1, 0xff, length >> 3);
+        byte_index += length >> 3;
+        length &= 7;
     }
     
     /* Invariant: 0 <= length < 8 */


### PR DESCRIPTION
Given this is internal functionality, I wasn't sure how to evaluate this in place so I ran the following code:

```c
#include "bitmap.h"

using namespace std;

int main(void) {
    for (unsigned i = 0; i < 1024; i++) {
        for (unsigned j = 1; j < 4096; j++) {
            Bitmap b;
            b.Create(8192);
            b.SetBits(i, j);
        }
    }
    return 0;
}
```

A fairly coarse grained evaluation, but running with the old version of bitmap.cpp on x86_64 I get:

```bash
$ time ./a.out
./a.out  1.88s user 0.00s system 99% cpu 1.882 total
```

and then after applying these changes:

```bash
$ time ./a.out
./a.out  0.40s user 0.00s system 98% cpu 0.400 total
```

To me, this change looks safely portable and should be as fast or faster on all architectures, but I don't have any others available to test. Please let me know if you think this will not work or will regress performance on some target platform.

----

While playing around in bitmap.cpp, it occurs to me that this can probably be entirely replaced by `vector<bool>`. I haven't attempted this and measured the result, but I would expect this to be noticeably faster as well. Would it be palatable to replace the bitmap implementation with a standard vector? There may be some constraint here I'm not aware of.