### PR TITLE
Always include long long Make_fixed_precision

### DIFF
--- a/libpolyml/run_time.cpp
+++ b/libpolyml/run_time.cpp
@@ -380,7 +380,6 @@ Handle Make_fixed_precision(TaskData *taskData, unsigned long uval)
     return taskData->saveVec.push(TAGGED(uval));
 }
 
-#if (SIZEOF_LONG_LONG != 0) && (SIZEOF_LONG_LONG <= SIZEOF_VOIDP)
 Handle Make_fixed_precision(TaskData *taskData, long long val)
 {
     if (val > MAXTAGGED || val < -MAXTAGGED-1)
@@ -394,7 +393,6 @@ Handle Make_fixed_precision(TaskData *taskData, unsigned long long uval)
         raise_exception0(taskData, EXC_overflow);
     return taskData->saveVec.push(TAGGED(uval));
 }
-#endif
 
 Handle Make_sysword(TaskData *taskData, uintptr_t p)
 {

--- a/libpolyml/run_time.h
+++ b/libpolyml/run_time.h
@@ -86,10 +86,8 @@ extern Handle Make_fixed_precision(TaskData *taskData, unsigned long);
 extern Handle Make_fixed_precision(TaskData *taskData, int);
 extern Handle Make_fixed_precision(TaskData *taskData, unsigned);
 
-#if (SIZEOF_LONG_LONG != 0) && (SIZEOF_LONG_LONG <= SIZEOF_VOIDP)
 extern Handle Make_fixed_precision(TaskData *taskData, long long);
 extern Handle Make_fixed_precision(TaskData *taskData, unsigned long long);
-#endif
 
 extern Handle Make_sysword(TaskData *taskData, uintptr_t p);
 


### PR DESCRIPTION
One of the users of this function is getStatInfo in unix_specific, which
converts a struct stat's st_nlink. However, on x32, st_nlink is a 64-bit
quantity (the system call ABI is 64-bit), so there are two problems.
Firstly, it will be truncated; secondly, since the long and int
overloads involve a cast to an integer of the same width, compilation
fails with an ambiguous call.