### PR TITLE
Fix installation error

### DIFF
--- a/modules/IntInfAsInt/Makefile.am
+++ b/modules/IntInfAsInt/Makefile.am
@@ -7,7 +7,7 @@ clean-local:
 
 install-exec-local:
 	$(mkdir_p) $(DESTDIR)$(moduledir)
-	$(INSTALL_PROGRAM)IntInfAsInt $(DESTDIR)$(moduledir)
+	$(INSTALL_PROGRAM) IntInfAsInt $(DESTDIR)$(moduledir)
 
 uninstall-local:
 	-rm -f $(DESTDIR)$(moduledir)/IntInfAsInt

--- a/modules/IntInfAsInt/Makefile.in
+++ b/modules/IntInfAsInt/Makefile.in
@@ -452,7 +452,7 @@ clean-local:
 
 install-exec-local:
 	$(mkdir_p) $(DESTDIR)$(moduledir)
-	$(INSTALL_PROGRAM)IntInfAsInt $(DESTDIR)$(moduledir)
+	$(INSTALL_PROGRAM) IntInfAsInt $(DESTDIR)$(moduledir)
 
 uninstall-local:
 	-rm -f $(DESTDIR)$(moduledir)/IntInfAsInt


### PR DESCRIPTION
The file name was being appended to `-c` in `$(INSTALL_PROGRAM)`, resulting in it being treated as some invalid options and causing `make install` to fail.