### PR TITLE
Fix MODULEDIR on Linux and wrong TextVersion

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -562,7 +562,7 @@ AM_CONDITIONAL([NO_UNDEFINED], [test "$poly_no_undefined" = yes])
 # Test whether this is a git directory and set the version if possible
 AC_CHECK_PROG([gitinstalled], [git], [yes], [no])
 if test X"$gitinstalled" = "Xyes" -a -d ".git"; then
-    GIT_VERSION='-DGIT_VERSION=$(shell git describe --tags --always)'
+    GIT_VERSION='-DGIT_VERSION=\"$(shell git describe --tags --always)\"'
     AC_SUBST(GIT_VERSION)
 fi
 

--- a/libpolyml/Makefile.am
+++ b/libpolyml/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS=foreign
 
 moduledir = @moduledir@
 
-AM_CPPFLAGS = $(CFLAGS) $(OSFLAG) $(GIT_VERSION) -Wall -DMODULEDIR=$(moduledir)
+AM_CPPFLAGS = $(CFLAGS) $(OSFLAG) $(GIT_VERSION) -Wall -DMODULEDIR=\"$(moduledir)\"
 AM_CFLAGS = $(CFLAGS) $(OSFLAG) $(GIT_VERSION) -Wall -fno-strict-aliasing
 AM_ASFLAGS = $(OSFLAG)
 AM_CCASFLAGS = $(OSFLAG)

--- a/libpolyml/poly_specific.cpp
+++ b/libpolyml/poly_specific.cpp
@@ -73,13 +73,8 @@ extern "C" {
 static const char *poly_runtime_system_copyright =
 "Copyright (c) 2002-17 David C.J. Matthews, CUTS and contributors.";
 
-#define Str(x) #x
-#define Xstr(x) Str(x)
-
-#ifdef GIT_VERSION
-#define GitVersion             Xstr(GIT_VERSION)
-#else
-#define GitVersion             ""
+#ifndef GIT_VERSION
+#define GIT_VERSION             ""
 #endif
 
 
@@ -90,7 +85,7 @@ Handle poly_dispatch_c(TaskData *taskData, Handle args, Handle code)
     {
     case 9: // Return the GIT version if appropriate
         {
-             return SAVE(C_string_to_Poly(taskData, GitVersion));
+             return SAVE(C_string_to_Poly(taskData, GIT_VERSION));
         }
 
     case 10: // Return the RTS version string.

--- a/libpolyml/poly_specific.cpp
+++ b/libpolyml/poly_specific.cpp
@@ -173,7 +173,7 @@ Handle poly_dispatch_c(TaskData *taskData, Handle args, Handle code)
     case 34: // Return the system directory for modules.  This is configured differently
         // in Unix and in Windows.
 #if (defined(MODULEDIR))
-    return SAVE(C_string_to_Poly(taskData, Xstr(MODULEDIR)));
+    return SAVE(C_string_to_Poly(taskData, MODULEDIR));
 #elif (defined(_WIN32) && ! defined(__CYGWIN__))
         {
             // This registry key is configured when Poly/ML is installed using the installer.

--- a/libpolyml/version.h
+++ b/libpolyml/version.h
@@ -33,6 +33,6 @@
 #define FIRST_supported_version 570
 #define LAST_supported_version  570
 
-#define TextVersion             "5.6"
+#define TextVersion             "5.7"
 
 #endif


### PR DESCRIPTION
The patches themselves are (hopefully) fairly self-explanatory. Regarding the -DFOO= + Xstr(FOO) uses, this is a minimal fix, but is there a reason why config.h can't be used for them like everything else?