### PR TITLE
Install built modules as data rather than executables

### DIFF
--- a/modules/IntInfAsInt/Makefile.am
+++ b/modules/IntInfAsInt/Makefile.am
@@ -7,7 +7,7 @@ clean-local:
 
 install-exec-local:
 	$(mkdir_p) $(DESTDIR)$(moduledir)
-	$(INSTALL_PROGRAM) IntInfAsInt $(DESTDIR)$(moduledir)
+	$(INSTALL_DATA) IntInfAsInt $(DESTDIR)$(moduledir)
 
 uninstall-local:
 	-rm -f $(DESTDIR)$(moduledir)/IntInfAsInt

--- a/modules/IntInfAsInt/Makefile.in
+++ b/modules/IntInfAsInt/Makefile.in
@@ -452,7 +452,7 @@ clean-local:
 
 install-exec-local:
 	$(mkdir_p) $(DESTDIR)$(moduledir)
-	$(INSTALL_PROGRAM) IntInfAsInt $(DESTDIR)$(moduledir)
+	$(INSTALL_DATA) IntInfAsInt $(DESTDIR)$(moduledir)
 
 uninstall-local:
 	-rm -f $(DESTDIR)$(moduledir)/IntInfAsInt


### PR DESCRIPTION
`INSTALL_PROGRAM` makes the installed file executable, but modules don't need to be, so should be installed as data instead (but still with `install-exec-local` as they're platform-specific and in a subdirectory of `libdir`).