### PR TITLE
[RFC] Replace remaining memory management in PExport::exportStore

### DIFF
--- a/libpolyml/pexport.cpp
+++ b/libpolyml/pexport.cpp
@@ -62,12 +62,10 @@ in a new session.
 
 PExport::PExport()
 {
-    indexOrder = 0;
 }
 
 PExport::~PExport()
 {
-    free(indexOrder);
 }
 
 
@@ -243,33 +241,26 @@ void PExport::ScanConstant(PolyObject *base, byte *addr, ScanRelocationKind code
 
 void PExport::exportStore(void)
 {
-    size_t i;
-
     // We want the entries in pMap to be in ascending
     // order of address to make searching easy so we need to process the areas
     // in order of increasing address, which may not be the order in memTable.
-    indexOrder = (size_t*)calloc(sizeof(size_t), memTableEntries);
-    if (indexOrder == 0)
-        throw MemoryException();
+    std::vector<size_t> indexOrder;
+    indexOrder.reserve(memTableEntries);
 
-    size_t items = 0;
-    for (i = 0; i < memTableEntries; i++)
+    for (size_t i = 0; i < memTableEntries; i++)
     {
-        size_t j = items;
-        while (j > 0 && memTable[i].mtAddr < memTable[indexOrder[j-1]].mtAddr)
-        {
-            indexOrder[j] = indexOrder[j-1];
-            j--;
+        std::vector<size_t>::iterator it;
+        for (it = indexOrder.begin(); it != indexOrder.end(); it++) {
+            if (memTable[*it].mtAddr >= memTable[i].mtAddr)
+                break;
         }
-        indexOrder[j] = i;
-        items++;
+        indexOrder.insert(it, i);
     }
-    ASSERT(items == memTableEntries);
 
     // Process the area in order of ascending address.
-    for (i = 0; i < items; i++)
+    for (std::vector<size_t>::iterator i = indexOrder.begin(); i != indexOrder.end(); i++)
     {
-        size_t index = indexOrder[i];
+        size_t index = indexOrder[*i];
         char *start = (char*)memTable[index].mtAddr;
         char *end = start + memTable[index].mtLength;
         for (PolyWord *p = (PolyWord*)start; p < (PolyWord*)end; )
@@ -287,7 +278,7 @@ void PExport::exportStore(void)
     fprintf(exportFile, "Root\t%zu\n", getIndex(rootFunction));
 
     // Generate each of the areas.
-    for (i = 0; i < memTableEntries; i++)
+    for (size_t i = 0; i < memTableEntries; i++)
     {
         char *start = (char*)memTable[i].mtAddr;
         char *end = start + memTable[i].mtLength;

--- a/libpolyml/pexport.cpp
+++ b/libpolyml/pexport.cpp
@@ -243,19 +243,19 @@ void PExport::ScanConstant(PolyObject *base, byte *addr, ScanRelocationKind code
 
 void PExport::exportStore(void)
 {
-    unsigned i;
+    size_t i;
 
     // We want the entries in pMap to be in ascending
     // order of address to make searching easy so we need to process the areas
     // in order of increasing address, which may not be the order in memTable.
-    indexOrder = (unsigned*)calloc(sizeof(unsigned), memTableEntries);
+    indexOrder = (size_t*)calloc(sizeof(size_t), memTableEntries);
     if (indexOrder == 0)
         throw MemoryException();
 
-    unsigned items = 0;
+    size_t items = 0;
     for (i = 0; i < memTableEntries; i++)
     {
-        unsigned j = items;
+        size_t j = items;
         while (j > 0 && memTable[i].mtAddr < memTable[indexOrder[j-1]].mtAddr)
         {
             indexOrder[j] = indexOrder[j-1];
@@ -269,7 +269,7 @@ void PExport::exportStore(void)
     // Process the area in order of ascending address.
     for (i = 0; i < items; i++)
     {
-        unsigned index = indexOrder[i];
+        size_t index = indexOrder[i];
         char *start = (char*)memTable[index].mtAddr;
         char *end = start + memTable[index].mtLength;
         for (PolyWord *p = (PolyWord*)start; p < (PolyWord*)end; )

--- a/libpolyml/pexport.h
+++ b/libpolyml/pexport.h
@@ -58,7 +58,6 @@ private:
     virtual PolyWord createRelocation(PolyWord p, void *relocAddr) { return p; }
 
     std::vector<PolyObject *> pMap;
-    size_t *indexOrder;
 
 };
 

--- a/libpolyml/pexport.h
+++ b/libpolyml/pexport.h
@@ -58,7 +58,7 @@ private:
     virtual PolyWord createRelocation(PolyWord p, void *relocAddr) { return p; }
 
     std::vector<PolyObject *> pMap;
-    unsigned *indexOrder;
+    size_t *indexOrder;
 
 };
 


### PR DESCRIPTION
This patch series does three things:

1. use a `size_t` for indexing an array instead of `unsigned`;
2. use a `std::vector` instead of `calloc` for an array in `PExport::exportStore`; and
3. remove persistence of `indexOrder` as a member variable of `PExport`.

The test suite does not appear to exercise this code and I don't have a good way of testing these changes, but this seems like a move in the right direction to me (less manual memory management, smaller scope of memory allocations). Just wanted to post this to see what you think. As I said, I haven't tested this so please don't assume it works it works as-is. Thanks as always.