### PR TITLE
fix unchecked malloc in ShowParent

### DIFF
--- a/libpolyml/savestate.cpp
+++ b/libpolyml/savestate.cpp
@@ -1378,6 +1378,8 @@ Handle ShowParent(TaskData *taskData, Handle hFileName)
     if ((FILE*)loadFile == NULL)
     {
         AutoFree<char*> buff((char *)malloc(23 + _tcslen(fileNameBuff) * sizeof(TCHAR) + 1));
+        if (buff == NULL)
+            raise_syscall(taskData, "Insufficient memory", NOMEMORY);
 #if (defined(_WIN32) && defined(UNICODE))
         sprintf(buff, "Cannot open load file: %S", (TCHAR *)fileNameBuff);
 #else


### PR DESCRIPTION
Other memory allocations in this function anticipate failure and call
raise_syscall, but this one was not.