### PR TITLE
fix some specifiers in formatting strings

### DIFF
--- a/libpolyml/check_objects.cpp
+++ b/libpolyml/check_objects.cpp
@@ -96,7 +96,7 @@ void DoCheckObject (const PolyObject *base, POLYUNSIGNED L)
     CheckAddress(pt);
     MemSpace *space = gMem.SpaceForAddress(pt-1);
     if (space == 0)
-        Crash ("Bad pointer 0x%08x found", pt);
+        Crash ("Bad pointer 0x%08" PRIxPTR " found", (uintptr_t)pt);
 
     ASSERT (OBJ_IS_LENGTH(L));
 

--- a/libpolyml/gc.cpp
+++ b/libpolyml/gc.cpp
@@ -111,7 +111,7 @@ static bool doGC(const POLYUNSIGNED wordsRequiredToAllocate)
     gMem.RemoveEmptyLocals();
 
     if (debugOptions & DEBUG_GC)
-        Log("GC: Full GC, %lu words required %u spaces\n", wordsRequiredToAllocate, gMem.lSpaces.size());
+        Log("GC: Full GC, %lu words required %zu spaces\n", wordsRequiredToAllocate, gMem.lSpaces.size());
 
     if (debugOptions & DEBUG_HEAPSIZE)
         gMem.ReportHeapSizes("Full GC (before)");
@@ -252,7 +252,7 @@ static bool doGC(const POLYUNSIGNED wordsRequiredToAllocate)
         for(std::vector<LocalMemSpace*>::iterator i = gMem.lSpaces.begin(); i < gMem.lSpaces.end(); i++)
         {
             LocalMemSpace *lSpace = *i;
-            Log("GC: %s space %p %d free in %d words %2.1f%% full\n", lSpace->spaceTypeString(),
+            Log("GC: %s space %p %zu free in %zu words %2.1f%% full\n", lSpace->spaceTypeString(),
                 lSpace, lSpace->freeSpace(), lSpace->spaceSize(),
                 ((float)lSpace->allocatedSpace()) * 100 / (float)lSpace->spaceSize());
         }
@@ -284,7 +284,7 @@ static bool doGC(const POLYUNSIGNED wordsRequiredToAllocate)
         memset(space->bottom, 0xaa, (char*)space->upperAllocPtr - (char*)space->bottom);
 #endif
         if (debugOptions & DEBUG_GC_ENHANCED)
-            Log("GC: %s space %p %d free in %d words %2.1f%% full\n", space->spaceTypeString(),
+            Log("GC: %s space %p %zu free in %zu words %2.1f%% full\n", space->spaceTypeString(),
                 space, space->freeSpace(), space->spaceSize(),
                 ((float)space->allocatedSpace()) * 100 / (float)space->spaceSize());
     }

--- a/libpolyml/memmgr.cpp
+++ b/libpolyml/memmgr.cpp
@@ -1047,7 +1047,7 @@ void MemMgr::ReportHeapSizes(const char *phase)
     Log(" (%1.0f%%). Total space ", (float)inAlloc / (float)alloc * 100.0F);
     LogSize(spaceForHeap);
     Log(" %1.0f%% full.\n", (float)(inAlloc + inNonAlloc) / (float)spaceForHeap * 100.0F);
-    Log("Heap: Local spaces %u, permanent spaces %u, code spaces %u, stack spaces %u\n",
+    Log("Heap: Local spaces %zu, permanent spaces %zu, code spaces %zu, stack spaces %zu\n",
         lSpaces.size(), pSpaces.size(), cSpaces.size(), sSpaces.size());
     POLYUNSIGNED cTotal = 0, cOccupied = 0;
     for (std::vector<CodeSpace*>::iterator c = cSpaces.begin(); c != cSpaces.end(); c++)

--- a/libpolyml/quick_gc.cpp
+++ b/libpolyml/quick_gc.cpp
@@ -644,7 +644,7 @@ bool RunQuickGC(const POLYUNSIGNED wordsRequiredToAllocate)
             else free = lSpace->freeSpace();
 
             if (debugOptions & DEBUG_GC_ENHANCED)
-                Log("GC: %s space %p %d free in %d words %2.1f%% full\n", lSpace->spaceTypeString(),
+                Log("GC: %s space %p %zu free in %zu words %2.1f%% full\n", lSpace->spaceTypeString(),
                     lSpace, lSpace->freeSpace(), lSpace->spaceSize(),
                     ((float)lSpace->allocatedSpace()) * 100 / (float)lSpace->spaceSize());
             globalStats.incSize(PSS_AFTER_LAST_GC, free*sizeof(PolyWord));

--- a/libpolyml/sharedata.cpp
+++ b/libpolyml/sharedata.cpp
@@ -1002,7 +1002,7 @@ bool ShareDataClass::RunShareData(PolyObject *root)
             DepthVector *v = depthVectorArray[j].vector[0];
             // Log this because it could be very large.
             if (debugOptions & DEBUG_SHARING)
-                Log("Sharing: Level %4" POLYUFMT ", size %3u, Objects %6" POLYUFMT "\n", 0, j, v->ItemCount());
+                Log("Sharing: Level %4" POLYUFMT ", size %3u, Objects %6" POLYUFMT "\n", 0ul, j, v->ItemCount());
             v->FixLengthAndAddresses(&fixup);
         }
     }


### PR DESCRIPTION
When teaching compilers that `Crash`, `Log` and `Exit` are printf-like (with
`__attribute__((format(printf...)))`) they note that we are calling these
functions with format specifiers that are of different widths and/or signs than
their corresponding arguments in some cases. This commit fixes all such
instances.

The `zu` specifier that I've used in a couple of places is only supported in more recent compilers (e.g. VS < 2013 did not support it) but I'm assuming it's fine to use as it's already in other places in the code base. Nevertheless it might be worth getting anyone who uses older compilers to test this patch.