### PR TITLE
Fix Posix lseek by using the correct dispatch call number.

### DIFF
--- a/basis/Posix.sml
+++ b/basis/Posix.sml
@@ -1340,7 +1340,7 @@ struct
         local
             val doCall = osSpecificGeneral
         in
-            fun lseek(fd, pos, whence) = doCall(115, (fd, pos, seekWhence whence))
+            fun lseek(fd, pos, whence) = doCall(118, (fd, pos, seekWhence whence))
         end
 
         local


### PR DESCRIPTION
Posix lseek was broken since it was using the call number for setfd.
