### PR TITLE
Add support for RISC-V

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -475,6 +475,12 @@
 /* Define if the host is a PowerPC (64-bit) */
 #undef HOSTARCHITECTURE_PPC64
 
+/* Define if the host is an RISC-V (32-bit) */
+#undef HOSTARCHITECTURE_RISCV32
+
+/* Define if the host is an RISC-V (64-bit) */
+#undef HOSTARCHITECTURE_RISCV64
+
 /* Define if the host is an S/390 (32-bit) */
 #undef HOSTARCHITECTURE_S390
 

--- a/configure.ac
+++ b/configure.ac
@@ -500,6 +500,14 @@ case "${host_cpu}" in
             CFLAGS="$CFLAGS -mieee -mfp-rounding-mode=d"
             CXXFLAGS="$CXXFLAGS -mieee -mfp-rounding-mode=d"
             ;;
+      riscv32)
+            AC_DEFINE([HOSTARCHITECTURE_RISCV32], [1], [Define if the host is a RISC-V (32-bit)])
+            polyarch=interpret
+            ;;
+      riscv64)
+            AC_DEFINE([HOSTARCHITECTURE_RISCV64], [1], [Define if the host is a RISC-V (64-bit)])
+            polyarch=interpret
+            ;;
       *) AC_MSG_ERROR([Poly/ML is not supported for this architecture]) ;;
 esac
 

--- a/libpolyml/elfexport.cpp
+++ b/libpolyml/elfexport.cpp
@@ -241,6 +241,33 @@
 # define HOST_DIRECT_DATA_RELOC R_ALPHA_REFQUAD
 # define HOST_DIRECT_FPTR_RELOC R_ALPHA_REFQUAD
 # define USE_RELA 1
+#elif defined(HOSTARCHITECTURE_RISCV32) || defined(HOSTARCHITECTURE_RISCV64)
+# define HOST_E_MACHINE EM_RISCV
+# if defined(HOSTARCHITECTURE_RISCV32)
+#  define HOST_DIRECT_DATA_RELOC R_RISCV_32
+#  define HOST_DIRECT_FPTR_RELOC R_RISCV_32
+# else
+#  define HOST_DIRECT_DATA_RELOC R_RISCV_64
+#  define HOST_DIRECT_FPTR_RELOC R_RISCV_64
+# endif
+# if defined(__riscv_float_abi_soft)
+#  define HOST_E_FLAGS_FLOAT_ABI EF_RISCV_FLOAT_ABI_SOFT
+# elif defined(__riscv_float_abi_single)
+#  define HOST_E_FLAGS_FLOAT_ABI EF_RISCV_FLOAT_ABI_SINGLE
+# elif defined(__riscv_float_abi_double)
+#  define HOST_E_FLAGS_FLOAT_ABI EF_RISCV_FLOAT_ABI_DOUBLE
+# elif defined(__riscv_float_abi_quad)
+#  define HOST_E_FLAGS_FLOAT_ABI EF_RISCV_FLOAT_ABI_QUAD
+# else
+#  error "Unknown RISC-V float ABI"
+# endif
+# ifdef __riscv_32e
+#  define HOST_E_FLAGS_RVE __riscv_32e
+# else
+#  define HOST_E_FLAGS_RVE 0
+# endif
+# define HOST_E_FLAGS (HOST_E_FLAGS_FLOAT_ABI | HOST_E_FLAGS_RVE)
+# define USE_RELA 1
 #else
 # error "No support for exporting on this architecture"
 #endif


### PR DESCRIPTION
This has been tested in a Debian sid riscv64 chroot using qemu-user. The bundled libffi is too old to support RISC-V, so I patched it locally (and will be carrying a patch in the Debian packaging; it'd be nice if `--with-system-libffi` could have a way of not even configuring libffi, to avoid needing support for new architectures in the bundled libffi, as its configure script fails if building for an unknown architecture). There is a libffi 3.3-rc0 which could in theory be used to update the bundled libffi, but it's probably best to just wait until a proper release and require users/distributions to patch the embedded libffi like I am doing if they want to build for RISC-V.