### PR TITLE
Fixes 5.8

### DIFF
--- a/Tests/Succeed/Test187.ML
+++ b/Tests/Succeed/Test187.ML
@@ -1,0 +1,4 @@
+(* This could segfault if GMP was enabled due to a bug in neg_longc. *)
+
+val x = ~ (LargeInt.fromInt(valOf FixedInt.maxInt)) - 1;
+PolyML.IntInf.gcd(x, 0);

--- a/configure
+++ b/configure
@@ -22488,7 +22488,7 @@ fi
 
 # If we're building only the static version of libpolyml
 # then polyc and polyml.pc have to include the dependent libraries.
-dependentlibs = ""
+dependentlibs=""
 if test "${enable_shared}" != yes; then
     dependentlibs=${LIBS}
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -581,7 +581,7 @@ AM_CONDITIONAL([MACOSLDOPTS], [test "$poly_need_macosopt" = yes ])
 
 # If we're building only the static version of libpolyml
 # then polyc and polyml.pc have to include the dependent libraries.
-dependentlibs = ""
+dependentlibs=""
 if test "${enable_shared}" != yes; then
     dependentlibs=${LIBS}
 fi

--- a/libpolyml/arb.cpp
+++ b/libpolyml/arb.cpp
@@ -594,7 +594,7 @@ Handle neg_longc(TaskData *taskData, Handle x)
     Handle long_y = alloc_and_save(taskData, WORDS(bytes), F_MUTABLE_BIT|F_BYTE_OBJ);
     byte *v = DEREFBYTEHANDLE(long_y);
     if (IS_INT(DEREFWORD(x)))
-        memcpy(v, (byte*)x_extend, bytes);
+        memcpy(v, &x_extend, bytes);
     else memcpy(v, DEREFBYTEHANDLE(x), bytes);
 #ifndef USE_GMP
     // Make sure the last word is zero.  We may have unused bytes there.

--- a/libpolyml/basicio.cpp
+++ b/libpolyml/basicio.cpp
@@ -200,7 +200,7 @@ int getStreamFileDescriptorWithoutCheck(PolyWord strm)
     // the standard streams which are tagged integers.
     if (strm.IsTagged())
         return strm.UnTagged();
-    return *(int*)(strm.AsObjPtr()) -1;
+    return *(intptr_t*)(strm.AsObjPtr()) -1;
 }
 
 // Most of the time we want to raise an exception if the file descriptor
@@ -254,7 +254,7 @@ static Handle close_file(TaskData *taskData, Handle stream)
     if (descr > 2)
     {
         close(descr);
-        *(int*)(stream->WordP()) = 0; // Mark as closed
+        *(intptr_t*)(stream->WordP()) = 0; // Mark as closed
     }
 
     return Make_fixed_precision(taskData, 0);
@@ -798,9 +798,6 @@ static Handle IO_dispatch_c(TaskData *taskData, Handle args, Handle strm, Handle
     case 6: /* Open file for binary output. */
         return open_file(taskData, args, O_WRONLY | O_CREAT | O_TRUNC, 0666, 0);
     case 7: /* Close file */
-        // Legacy: During the bootstrap we will have old format references.
-        if (strm->Word().IsTagged())
-            return Make_fixed_precision(taskData, 0);
         return close_file(taskData, strm);
     case 8: /* Read text into an array. */
         return readArray(taskData, strm, args, true);

--- a/libpolyml/interpret.cpp
+++ b/libpolyml/interpret.cpp
@@ -1329,7 +1329,9 @@ int IntTaskData::SwitchToPoly()
             Handle reset = this->saveVec.mark();
             Handle pushedArg1 = this->saveVec.push(*sp++);
             Handle pushedArg2 = this->saveVec.push(*sp);
+            SaveInterpreterState(pc, sp); // mult_longc allocates memory and may GC even if it doesn't overflow.
             Handle result = mult_longc(this, pushedArg2, pushedArg1);
+            LoadInterpreterState(pc, sp);
             PolyWord res = result->Word();
             this->saveVec.reset(reset);
             if (! res.IsTagged()) 

--- a/libpolyml/poly_specific.cpp
+++ b/libpolyml/poly_specific.cpp
@@ -376,11 +376,21 @@ POLYUNSIGNED PolySetCodeConstant(PolyWord closure, PolyWord offset, PolyWord cWo
         case 0: // Absolute constant - size PolyWord
         {
             POLYUNSIGNED c = cWord.AsUnsigned();
+#ifdef WORDS_BIGENDIAN
+            // This is used to store constants in the constant area
+            // on the interpreted version. 
+            for (unsigned i = sizeof(PolyWord); i > 0; i--)
+            {
+                pointer[i-1] = (byte)(c & 255);
+                c >>= 8;
+            }
+#else
             for (unsigned i = 0; i < sizeof(PolyWord); i++)
             {
                 pointer[i] = (byte)(c & 255);
                 c >>= 8;
             }
+#endif
             break;
         }
         case 1: // Relative constant - X86 - size 4 bytes

--- a/mlsource/MLCompiler/CodeTree/CODETREE_SIMPLIFIER.sml
+++ b/mlsource/MLCompiler/CodeTree/CODETREE_SIMPLIFIER.sml
@@ -1108,12 +1108,12 @@ struct
         |   (WordLogical logop, arg1, arg2 as Constnt(v2, _)) =>
             (* Return the zero if we are anding with zero otherwise the original arg *)
             if isShort v2 andalso toShort v2 = 0w0
-            then (case logop of LogicalAnd => arg2 | _ => arg1, decArgs, EnvSpecNone)
+            then (case logop of LogicalAnd => CodeZero | _ => arg1, decArgs, EnvSpecNone)
             else (Binary{oper=oper, arg1=genArg1, arg2=genArg2}, decArgs, EnvSpecNone)
 
         |   (WordLogical logop, Constnt(v1, _), arg2) =>
             if isShort v1 andalso toShort v1 = 0w0
-            then (case logop of LogicalAnd => arg2 | _ => arg2, decArgs, EnvSpecNone)
+            then (case logop of LogicalAnd => CodeZero | _ => arg2, decArgs, EnvSpecNone)
             else (Binary{oper=oper, arg1=genArg1, arg2=genArg2}, decArgs, EnvSpecNone)
         
             (* TODO: Constant folding of shifts. *)


### PR DESCRIPTION
In order to compile on MacOS 10.15 (Catalina) I had to comment line 58 of machoexport.cpp which attempts to include a <mach-o/ppc/reloc.h> which does not exist. I'm new to Git so pardon me if I'm not doing this right.