### PR TITLE
Fix LargeWord.fromInt for negative arguments

### DIFF
--- a/basis/LargeWord.sml
+++ b/basis/LargeWord.sml
@@ -277,7 +277,7 @@ in
         fun fromInt(i: int): word =
             if Bootstrap.intIsArbitraryPrecision
             then fromLargeInt(LargeInt.fromInt i)
-            else Word.toLargeWord(Word.fromInt i)
+            else Word.toLargeWordX(Word.fromInt i)
 
         and toInt(w: word): int =
             if Bootstrap.intIsArbitraryPrecision


### PR DESCRIPTION
Without IntInf as Int, conversion from int to large word is via word.
Word.wordSize < LargeWord.wordSize so conversion from word to large word
should sign extend.