### PR TITLE
remove UB left shift

### DIFF
--- a/libpolyml/realconv.cpp
+++ b/libpolyml/realconv.cpp
@@ -1254,7 +1254,7 @@ ulp
         else {
             word0(&u) = 0;
             L -= Exp_shift;
-            word1(&u) = L >= 31 ? 1 : 1 << 31 - L;
+            word1(&u) = L >= 31 ? 1 : 1L << 31 - L;
             }
         }
 #endif


### PR DESCRIPTION
The literal '1' has type int, and shifting left into the sign bit is undefined
behavior in C/C++. It is unlikely any compilers mis-compiled this, but better to
guard against this.