### PR TITLE
Add an option to start ML code in main (root) thread

### DIFF
--- a/libpolyml/mpoly.cpp
+++ b/libpolyml/mpoly.cpp
@@ -109,7 +109,8 @@ enum {
     OPT_DEBUGFILE,
     OPT_DDESERVICE,
     OPT_CODEPAGE,
-    OPT_REMOTESTATS
+    OPT_REMOTESTATS,
+    OPT_MAINTHREADML
 };
 
 static struct __argtab {
@@ -130,10 +131,11 @@ static struct __argtab {
 #ifdef UNICODE
     { _T("--codepage"),     "Code-page to use for file-names etc in Windows",       OPT_CODEPAGE },
 #endif
-    { _T("-pServiceName"),  "DDE service name for remote interrupt in Windows",     OPT_DDESERVICE }
+    { _T("-pServiceName"),  "DDE service name for remote interrupt in Windows",     OPT_DDESERVICE },
 #else
-    { _T("--exportstats"),  "Enable another process to read the statistics",        OPT_REMOTESTATS }
+    { _T("--exportstats"),  "Enable another process to read the statistics",        OPT_REMOTESTATS },
 #endif
+    {_T("--mainthreadml"),  "Start running ML code in main thread",                 OPT_MAINTHREADML }
 };
 
 static struct __debugOpts {
@@ -340,6 +342,11 @@ int polymain(int argc, TCHAR **argv, exportDescription *exports)
                     case OPT_REMOTESTATS:
                         // If set we export the statistics on Unix.
                         globalStats.exportStats = true;
+                        break;
+
+                    case OPT_MAINTHREADML:
+                        // Start running ML code in main thread.
+                        userOptions.startMLCodeInMainThread = true;
                         break;
                     }
                     argUsed = true;

--- a/libpolyml/mpoly.h
+++ b/libpolyml/mpoly.h
@@ -37,6 +37,7 @@ extern struct _userOptions {
     TCHAR       **user_arg_strings;
     const TCHAR *programName;
     unsigned    gcthreads;    // Number of threads to use for gc
+    bool        startMLCodeInMainThread; // Start ML code in main thread
 } userOptions;
 
 class PolyWord;

--- a/libpolyml/processes.cpp
+++ b/libpolyml/processes.cpp
@@ -192,6 +192,7 @@ public:
 public:
     void BroadcastInterrupt(void);
     void BeginRootThread(PolyObject *rootFunction);
+    void WaitForTermination(); // Main loop to wait until the threads terminate or make a request.
     void RequestProcessExit(int n); // Request all ML threads to exit and set the process result code.
     // Called when a thread has completed - doesn't return.
     virtual NORETURNFN(void ThreadExit(TaskData *taskData));
@@ -1292,6 +1293,12 @@ static DWORD WINAPI NewThreadFunction(void *parameter)
 }
 #endif
 
+static void *WaitForTermination(void *processes)
+{
+    ((Processes *)processes)->WaitForTermination();
+    return NULL; // This function should never return.
+}
+
 // Sets up the initial thread from the root function.  This is run on
 // the initial thread of the process so it will work if we don't
 // have pthreads.
@@ -1305,7 +1312,6 @@ static DWORD WINAPI NewThreadFunction(void *parameter)
 // on the inital thread.
 void Processes::BeginRootThread(PolyObject *rootFunction)
 {
-    int exitLoopCount = 100; // Maximum 100 * 400 ms.
     if (taskArray.size() < 1) {
         try {
             taskArray.push_back(0);
@@ -1314,9 +1320,10 @@ void Processes::BeginRootThread(PolyObject *rootFunction)
         }
     }
 
+    TaskData *taskData;
     try {
         // We can't use ForkThread because we don't have a taskData object before we start
-        TaskData *taskData = machineDependent->CreateTaskData();
+        taskData = machineDependent->CreateTaskData();
         Handle threadRef = MakeVolatileWord(taskData, taskData);
         taskData->threadObject = (ThreadObject*)alloc(taskData, sizeof(ThreadObject) / sizeof(PolyWord), F_MUTABLE_BIT);
         taskData->threadObject->threadRef = threadRef->Word();
@@ -1352,16 +1359,31 @@ void Processes::BeginRootThread(PolyObject *rootFunction)
             NewThreadFunction(taskData);
         }
 
-        schedLock.Lock();
         int errorCode = 0;
+        schedLock.Lock();
+        if (userOptions.startMLCodeInMainThread)
+        {
+            // Spawn termination handling in new thread, and run ML code in current thread.
 #if (!defined(_WIN32))
-        if (pthread_create(&taskData->threadId, NULL, NewThreadFunction, taskData) != 0)
-            errorCode = errno;
+            if (pthread_create(&taskData->threadId, NULL, ::WaitForTermination, this) != 0)
+                errorCode = errno;
 #else
-        taskData->threadHandle =
-            CreateThread(NULL, 0, NewThreadFunction, taskData, 0, NULL);
-        if (taskData->threadHandle == NULL) errorCode = GetLastError();
+            taskData->threadHandle =
+                CreateThread(NULL, 0, ::WaitForTermination, this, 0, NULL);
+            if (taskData->threadHandle == NULL) errorCode = GetLastError();
 #endif
+        }
+        else
+        {
+#if (!defined(_WIN32))
+            if (pthread_create(&taskData->threadId, NULL, NewThreadFunction, taskData) != 0)
+                errorCode = errno;
+#else
+            taskData->threadHandle =
+                CreateThread(NULL, 0, NewThreadFunction, taskData, 0, NULL);
+            if (taskData->threadHandle == NULL) errorCode = GetLastError();
+#endif
+        }
         if (errorCode != 0)
         {
             // Thread creation failed.
@@ -1377,8 +1399,22 @@ void Processes::BeginRootThread(PolyObject *rootFunction)
         ::Exit("Unable to create the initial thread - insufficient memory");
     }
 
-    // Wait until the threads terminate or make a request.
-    // We only release schedLock while waiting.
+    if (userOptions.startMLCodeInMainThread)
+    {
+        // Run ML code in main thread.
+        NewThreadFunction(taskData);
+    }
+    else
+    {
+        WaitForTermination();
+    }
+}
+
+// Wait until the threads terminate or make a request.
+// We only release schedLock while waiting.
+void Processes::WaitForTermination()
+{
+    int exitLoopCount = 100; // Maximum 100 * 400 ms.
     while (1)
     {
         // Look at the threads to see if they are running.


### PR DESCRIPTION
In newer versions of Mac OS X, Apple libraries attempt to assert and
enforce that all UI code and event handling code be run from the main
thread. This swaps the polymain logic such that we start ML code from
the main thread and handle termination in the newly spawned thread
through the option `--mainthreadml 1`

See #146 for specific repro context.

I tried to run this and it apparently works. I'm not too familiar with the consequences of this in terms of GC and signal handling though, so feel free to suggest changes. I also happen to have no clue exactly what's going on with the Windows code (which doesn't have this problem probably), so I chucked the option in userOptions for now.
```
hys-macs ~/sandbox/sdl $ ../../projects/polyml/poly --mainthreadml 1
Poly/ML 5.8.2 Testing (Git version v5.8.1-327-gbf2020d0)
> use "test.sml";
val error = "": string
val sym = fn: string -> Foreign.symbol
val window = SOME ?: Foreign.Memory.voidStar option
val it = (): unit
> PolyML.fullGC ();
val it = (): unit
```