### PR TITLE
Add FFI conversions for C size types

### DIFF
--- a/basis/Foreign.sml
+++ b/basis/Foreign.sml
@@ -145,6 +145,8 @@ sig
         and cTypeUint: cType
         and cTypeLong: cType
         and cTypeUlong: cType
+        and cTypeSsize: cType
+        and cTypeSize: cType
         and cTypeFloat: cType
         and cTypeDouble: cType
         
@@ -207,6 +209,10 @@ sig
     val cUintLarge: LargeInt.int conversion
     val cLongLarge: LargeInt.int conversion
     val cUlongLarge: LargeInt.int conversion
+    val cSsize: int conversion
+    val cSize: int conversion
+    val cSsizeLarge: LargeInt.int conversion
+    val cSizeLarge: LargeInt.int conversion
     val cString: string conversion
     val cByteArray: Word8Vector.vector conversion
     val cFloat: real conversion
@@ -588,6 +594,12 @@ struct
                 { size= #size saLong, align= #align saLong, typeForm = CTypeSignedInt }
             val cTypeUlong =
                 { size= #size saLong, align= #align saLong, typeForm = CTypeSignedInt }
+            (* ssize_t *)
+            val cTypeSsize =
+                { size= #size saSsize, align= #align saSsize, typeForm = CTypeSignedInt }
+            (* size_t *)
+            val cTypeSize =
+                { size= #size saSize, align= #align saSize, typeForm = CTypeUnsignedInt }
             (* Float: 4 on X86 *)
             val cTypeFloat =
                 { size= #size saFloat, align= #align saFloat, typeForm = CTypeFloatingPt }
@@ -957,6 +969,26 @@ struct
             if #size saLong = #size (#ctype cUint32Large) then cUint32Large
             else if #size saLong = #size (#ctype cUint64Large) then cUint64Large
             else raise Foreign "Unable to find type for unsigned long"
+
+        val cSsize =
+            if #size saSsize = #size (#ctype cInt32) then cInt32
+            else if #size saSsize = #size (#ctype cInt64) then cInt64
+            else raise Foreign "Unable to find type for ssize_t"
+
+        val cSsizeLarge =
+            if #size saSsize = #size (#ctype cInt32Large) then cInt32Large
+            else if #size saSsize = #size (#ctype cInt64Large) then cInt64Large
+            else raise Foreign "Unable to find type for ssize_t"
+
+        val cSize =
+            if #size saSize = #size (#ctype cUint32) then cUint32
+            else if #size saSize = #size (#ctype cUint64) then cUint64
+            else raise Foreign "Unable to find type for size_t"
+
+        val cSizeLarge =
+            if #size saSize = #size (#ctype cUint32Large) then cUint32Large
+            else if #size saSize = #size (#ctype cUint64Large) then cUint64Large
+            else raise Foreign "Unable to find type for size_t"
 
         local
             fun load(s: voidStar): string =

--- a/basis/ForeignConstants.sml
+++ b/basis/ForeignConstants.sml
@@ -29,12 +29,16 @@ struct
         and sizeShort: word     = RunCall.rtsCallFast1 "PolySizeShort" ()
         and sizeInt: word       = RunCall.rtsCallFast1 "PolySizeInt" ()
         and sizeLong: word      = RunCall.rtsCallFast1 "PolySizeLong" ()
+        and sizeSsize: word     = RunCall.rtsCallFast1 "PolySizeSsize" ()
+        and sizeSize: word      = RunCall.rtsCallFast1 "PolySizeSize" ()
     in
         val saFloat     = {size=sizeFloat, align=sizeFloat}
         and saDouble    = {size=sizeDouble, align=sizeDouble}
         and saShort     = {size=sizeShort, align=sizeShort}
         and saInt       = {size=sizeInt, align=sizeInt}
         and saLong      = {size=sizeLong, align=sizeLong}
+        and saSsize     = {size=sizeSsize, align=sizeSsize}
+        and saSize      = {size=sizeSize, align=sizeSize}
     end
 
     val bigEndian : bool = LibrarySupport.bigEndian

--- a/libpolyml/polyffi.cpp
+++ b/libpolyml/polyffi.cpp
@@ -89,6 +89,8 @@ extern "C" {
     POLYEXTERNALSYMBOL POLYUNSIGNED PolySizeShort();
     POLYEXTERNALSYMBOL POLYUNSIGNED PolySizeInt();
     POLYEXTERNALSYMBOL POLYUNSIGNED PolySizeLong();
+    POLYEXTERNALSYMBOL POLYUNSIGNED PolySizeSsize();
+    POLYEXTERNALSYMBOL POLYUNSIGNED PolySizeSize();
     POLYEXTERNALSYMBOL POLYUNSIGNED PolyFFIGetError(POLYUNSIGNED addr);
     POLYEXTERNALSYMBOL POLYUNSIGNED PolyFFISetError(POLYUNSIGNED err);
     POLYEXTERNALSYMBOL POLYUNSIGNED PolyFFICreateExtFn(POLYUNSIGNED threadId, POLYUNSIGNED arg);
@@ -309,6 +311,16 @@ POLYUNSIGNED PolySizeLong()
     return TAGGED((POLYSIGNED)sizeof(long)).AsUnsigned();
 }
 
+POLYUNSIGNED PolySizeSsize()
+{
+    return TAGGED((POLYSIGNED)sizeof(ssize_t)).AsUnsigned();
+}
+
+POLYUNSIGNED PolySizeSize()
+{
+    return TAGGED((POLYSIGNED)sizeof(size_t)).AsUnsigned();
+}
+
 // Get either errno or GetLastError
 POLYUNSIGNED PolyFFIGetError(POLYUNSIGNED addr)
 {
@@ -393,6 +405,8 @@ struct _entrypts polyFFIEPT[] =
     { "PolySizeShort",                  (polyRTSFunction)&PolySizeShort},
     { "PolySizeInt",                    (polyRTSFunction)&PolySizeInt},
     { "PolySizeLong",                   (polyRTSFunction)&PolySizeLong},
+    { "PolySizeSsize",                  (polyRTSFunction)&PolySizeSsize},
+    { "PolySizeSize",                   (polyRTSFunction)&PolySizeSize},
     { "PolyFFIGetError",                (polyRTSFunction)&PolyFFIGetError},
     { "PolyFFISetError",                (polyRTSFunction)&PolyFFISetError},
     { "PolyFFICreateExtFn",             (polyRTSFunction)&PolyFFICreateExtFn},


### PR DESCRIPTION
This adds FFI conversions for the C types `size_t` and `ssize_t`, partially addressing #152.  The conversions use SML types `int` and `LargeInt.int` as for other conversions.  Conversions for other types mentioned in #152 could be added if this is the way to go.

I've check that this builds on Linux x86_64 and Darwin but not on Windows.