### PR TITLE
Adapt to nonconstant PTHREAD_STACK_MIN in glibc 2.34+

### DIFF
--- a/libpolyml/sighandler.cpp
+++ b/libpolyml/sighandler.cpp
@@ -547,11 +547,11 @@ void SigHandler::Init(void)
     pthread_attr_t attrs;
     pthread_attr_init(&attrs);
 #ifdef PTHREAD_STACK_MIN
-#if (PTHREAD_STACK_MIN < 4096)
-    pthread_attr_setstacksize(&attrs, 4096); // But not too small: FreeBSD makes it 2k
-#else
-    pthread_attr_setstacksize(&attrs, PTHREAD_STACK_MIN); // Only small stack.
-#endif
+    // In glibc 2.34 and later, PTHREAD_STACK_MIN may expand to a function call
+    size_t stacksize = PTHREAD_STACK_MIN; // Only small stack.
+    if (stacksize < 4096U) // But not too small: FreeBSD makes it 2k
+        stacksize = 4096U;
+    pthread_attr_setstacksize(&attrs, stacksize);
 #endif
     threadRunning = pthread_create(&detectionThreadId, &attrs, SignalDetectionThread, 0) == 0;
     pthread_attr_destroy(&attrs);


### PR DESCRIPTION
Fixes https://github.com/polyml/polyml/issues/155.  This patch has been tested on an x86_64 running Fedora Rawhide.