### PR TITLE
Add FFI conversions for C types

### DIFF
--- a/basis/Foreign.sml
+++ b/basis/Foreign.sml
@@ -205,14 +205,24 @@ sig
     val cUint: int conversion
     val cLong: int conversion
     val cUlong: int conversion
+    val cLonglong: int conversion
+    val cUlonglong: int conversion
     val cIntLarge: LargeInt.int conversion
     val cUintLarge: LargeInt.int conversion
     val cLongLarge: LargeInt.int conversion
     val cUlongLarge: LargeInt.int conversion
+    val cLonglongLarge: LargeInt.int conversion
+    val cUlonglongLarge: LargeInt.int conversion
     val cSsize: int conversion
     val cSize: int conversion
+    val cPtrdiff : int conversion
+    val cIntptr : int conversion
+    val cUintptr : int conversion
     val cSsizeLarge: LargeInt.int conversion
     val cSizeLarge: LargeInt.int conversion
+    val cPtrdiffLarge : LargeInt.int conversion
+    val cIntptrLarge : LargeInt.int conversion
+    val cUintptrLarge : LargeInt.int conversion
     val cString: string conversion
     val cByteArray: Word8Vector.vector conversion
     val cFloat: real conversion
@@ -594,12 +604,26 @@ struct
                 { size= #size saLong, align= #align saLong, typeForm = CTypeSignedInt }
             val cTypeUlong =
                 { size= #size saLong, align= #align saLong, typeForm = CTypeUnsignedInt }
+            (* long long *)
+            val cTypeLonglong =
+                { size= #size saLonglong, align= #align saLonglong, typeForm = CTypeSignedInt }
+            val cTypeUlonglong =
+                { size= #size saLonglong, align= #align saLonglong, typeForm = CTypeUnsignedInt }
             (* ssize_t *)
             val cTypeSsize =
                 { size= #size saSsize, align= #align saSsize, typeForm = CTypeSignedInt }
             (* size_t *)
             val cTypeSize =
                 { size= #size saSize, align= #align saSize, typeForm = CTypeUnsignedInt }
+            (* ptrdiff_t *)
+            val cTypePtrdiff =
+                { size= #size saPtrdiff, align= #align saPtrdiff, typeForm = CTypeSignedInt }
+            (* intptr_t *)
+            val cTypeIntptr =
+                { size= #size saIntptr, align= #align saIntptr, typeForm = CTypeSignedInt }
+            (* uintptr_t *)
+            val cTypeUintptr =
+                { size= #size saUintptr, align= #align saUintptr, typeForm = CTypeUnsignedInt }
             (* Float: 4 on X86 *)
             val cTypeFloat =
                 { size= #size saFloat, align= #align saFloat, typeForm = CTypeFloatingPt }
@@ -970,6 +994,26 @@ struct
             else if #size saLong = #size (#ctype cUint64Large) then cUint64Large
             else raise Foreign "Unable to find type for unsigned long"
 
+        val cLonglong =
+            if #size saLonglong = #size (#ctype cInt32) then cInt32
+            else if #size saLonglong = #size (#ctype cInt64) then cInt64
+            else raise Foreign "Unable to find type for long long"
+
+        val cLonglongLarge =
+            if #size saLonglong = #size (#ctype cInt32Large) then cInt32Large
+            else if #size saLonglong = #size (#ctype cInt64Large) then cInt64Large
+            else raise Foreign "Unable to find type for long long"
+
+        val cUlonglong = 
+            if #size saLonglong = #size (#ctype cUint32) then cUint32
+            else if #size saLonglong = #size (#ctype cUint64) then cUint64
+            else raise Foreign "Unable to find type for unsigned long long"
+
+        val cUlonglongLarge = 
+            if #size saLonglong = #size (#ctype cUint32Large) then cUint32Large
+            else if #size saLonglong = #size (#ctype cUint64Large) then cUint64Large
+            else raise Foreign "Unable to find type for unsigned long long"
+
         val cSsize =
             if #size saSsize = #size (#ctype cInt32) then cInt32
             else if #size saSsize = #size (#ctype cInt64) then cInt64
@@ -989,6 +1033,36 @@ struct
             if #size saSize = #size (#ctype cUint32Large) then cUint32Large
             else if #size saSize = #size (#ctype cUint64Large) then cUint64Large
             else raise Foreign "Unable to find type for size_t"
+
+        val cPtrdiff =
+            if #size saPtrdiff = #size (#ctype cInt32) then cInt32
+            else if #size saPtrdiff = #size (#ctype cInt64) then cInt64
+            else raise Foreign "Unable to find type for ptrdiff_t"
+
+        val cPtrdiffLarge =
+            if #size saPtrdiff = #size (#ctype cInt32Large) then cInt32Large
+            else if #size saPtrdiff = #size (#ctype cInt64Large) then cInt64Large
+            else raise Foreign "Unable to find type for ptrdiff_t"
+
+        val cIntptr =
+            if #size saIntptr = #size (#ctype cInt32) then cInt32
+            else if #size saIntptr = #size (#ctype cInt64) then cInt64
+            else raise Foreign "Unable to find type for intptr_t"
+
+        val cIntptrLarge =
+            if #size saIntptr = #size (#ctype cInt32Large) then cInt32Large
+            else if #size saIntptr = #size (#ctype cInt64Large) then cInt64Large
+            else raise Foreign "Unable to find type for intptr_t"
+
+        val cUintptr =
+            if #size saUintptr = #size (#ctype cUint32) then cUint32
+            else if #size saUintptr = #size (#ctype cUint64) then cUint64
+            else raise Foreign "Unable to find type for uintptr_t"
+
+        val cUintptrLarge =
+            if #size saUintptr = #size (#ctype cUint32Large) then cUint32Large
+            else if #size saUintptr = #size (#ctype cUint64Large) then cUint64Large
+            else raise Foreign "Unable to find type for uintptr_t"
 
         local
             fun load(s: voidStar): string =

--- a/basis/ForeignConstants.sml
+++ b/basis/ForeignConstants.sml
@@ -29,16 +29,24 @@ struct
         and sizeShort: word     = RunCall.rtsCallFast1 "PolySizeShort" ()
         and sizeInt: word       = RunCall.rtsCallFast1 "PolySizeInt" ()
         and sizeLong: word      = RunCall.rtsCallFast1 "PolySizeLong" ()
+        and sizeLonglong: word  = RunCall.rtsCallFast1 "PolySizeLonglong" ()
         and sizeSsize: word     = RunCall.rtsCallFast1 "PolySizeSsize" ()
         and sizeSize: word      = RunCall.rtsCallFast1 "PolySizeSize" ()
+        and sizePtrdiff: word   = RunCall.rtsCallFast1 "PolySizePtrdiff" ()
+        and sizeIntptr: word    = RunCall.rtsCallFast1 "PolySizeIntptr" ()
+        and sizeUintptr: word   = RunCall.rtsCallFast1 "PolySizeUintptr" ()
     in
         val saFloat     = {size=sizeFloat, align=sizeFloat}
         and saDouble    = {size=sizeDouble, align=sizeDouble}
         and saShort     = {size=sizeShort, align=sizeShort}
         and saInt       = {size=sizeInt, align=sizeInt}
         and saLong      = {size=sizeLong, align=sizeLong}
+        and saLonglong  = {size=sizeLonglong, align=sizeLonglong}
         and saSsize     = {size=sizeSsize, align=sizeSsize}
         and saSize      = {size=sizeSize, align=sizeSize}
+        and saPtrdiff   = {size=sizePtrdiff, align=sizePtrdiff}
+        and saIntptr    = {size=sizeIntptr, align=sizeIntptr}
+        and saUintptr   = {size=sizeUintptr, align=sizeUintptr}
     end
 
     val bigEndian : bool = LibrarySupport.bigEndian

--- a/configure.ac
+++ b/configure.ac
@@ -302,6 +302,10 @@ AC_CHECK_TYPES([SYSTEM_LOGICAL_PROCESSOR_INFORMATION],,,[#include "windows.h"])
 
 AC_CHECK_TYPES(long long)
 AC_CHECK_TYPES(ssize_t)
+AC_CHECK_TYPES([ptrdiff_t], [],
+  [AC_DEFINE_UNQUOTED([ptrdiff_t], [int],
+     [Define to `int' if <sys/types.h> does not define.])])
+
 
 AC_CHECK_SIZEOF(void*)
 AC_CHECK_SIZEOF(long)

--- a/libpolyml/polyffi.cpp
+++ b/libpolyml/polyffi.cpp
@@ -89,8 +89,12 @@ extern "C" {
     POLYEXTERNALSYMBOL POLYUNSIGNED PolySizeShort();
     POLYEXTERNALSYMBOL POLYUNSIGNED PolySizeInt();
     POLYEXTERNALSYMBOL POLYUNSIGNED PolySizeLong();
+    POLYEXTERNALSYMBOL POLYUNSIGNED PolySizeLonglong();
     POLYEXTERNALSYMBOL POLYUNSIGNED PolySizeSsize();
     POLYEXTERNALSYMBOL POLYUNSIGNED PolySizeSize();
+    POLYEXTERNALSYMBOL POLYUNSIGNED PolySizePtrdiff();
+    POLYEXTERNALSYMBOL POLYUNSIGNED PolySizeIntptr();
+    POLYEXTERNALSYMBOL POLYUNSIGNED PolySizeUintptr();
     POLYEXTERNALSYMBOL POLYUNSIGNED PolyFFIGetError(POLYUNSIGNED addr);
     POLYEXTERNALSYMBOL POLYUNSIGNED PolyFFISetError(POLYUNSIGNED err);
     POLYEXTERNALSYMBOL POLYUNSIGNED PolyFFICreateExtFn(POLYUNSIGNED threadId, POLYUNSIGNED arg);
@@ -311,6 +315,11 @@ POLYUNSIGNED PolySizeLong()
     return TAGGED((POLYSIGNED)sizeof(long)).AsUnsigned();
 }
 
+POLYUNSIGNED PolySizeLonglong()
+{
+    return TAGGED((POLYSIGNED)sizeof(long long)).AsUnsigned();
+}
+
 POLYUNSIGNED PolySizeSsize()
 {
     return TAGGED((POLYSIGNED)sizeof(ssize_t)).AsUnsigned();
@@ -319,6 +328,21 @@ POLYUNSIGNED PolySizeSsize()
 POLYUNSIGNED PolySizeSize()
 {
     return TAGGED((POLYSIGNED)sizeof(size_t)).AsUnsigned();
+}
+
+POLYUNSIGNED PolySizePtrdiff()
+{
+    return TAGGED((POLYSIGNED)sizeof(ptrdiff_t)).AsUnsigned();
+}
+
+POLYUNSIGNED PolySizeIntptr()
+{
+    return TAGGED((POLYSIGNED)sizeof(intptr_t)).AsUnsigned();
+}
+
+POLYUNSIGNED PolySizeUintptr()
+{
+    return TAGGED((POLYSIGNED)sizeof(uintptr_t)).AsUnsigned();
 }
 
 // Get either errno or GetLastError
@@ -405,8 +429,12 @@ struct _entrypts polyFFIEPT[] =
     { "PolySizeShort",                  (polyRTSFunction)&PolySizeShort},
     { "PolySizeInt",                    (polyRTSFunction)&PolySizeInt},
     { "PolySizeLong",                   (polyRTSFunction)&PolySizeLong},
+    { "PolySizeLonglong",               (polyRTSFunction)&PolySizeLonglong},
     { "PolySizeSsize",                  (polyRTSFunction)&PolySizeSsize},
     { "PolySizeSize",                   (polyRTSFunction)&PolySizeSize},
+    { "PolySizePtrdiff",                (polyRTSFunction)&PolySizePtrdiff},
+    { "PolySizeIntptr",                 (polyRTSFunction)&PolySizeIntptr},
+    { "PolySizeUintptr",                (polyRTSFunction)&PolySizeUintptr},
     { "PolyFFIGetError",                (polyRTSFunction)&PolyFFIGetError},
     { "PolyFFISetError",                (polyRTSFunction)&PolyFFISetError},
     { "PolyFFICreateExtFn",             (polyRTSFunction)&PolyFFICreateExtFn},


### PR DESCRIPTION
Conversions are added to the structure Foreign for the following C types:
- (signed) long long
- unsigned long long
- ptrdiff_t
- intptr_t
- uintptr_t