### PR TITLE
Partially fix behavior of `IEEEReal.scan`

### DIFF
--- a/Tests/Succeed/Test017.ML
+++ b/Tests/Succeed/Test017.ML
@@ -23,38 +23,6 @@ verify(valOf(#readVec r) 2 = "");
 
 Timer.checkCPUTimes(Timer.totalCPUTimer());
 
-
-fun ieeeVerify(SOME(iee, subs), ieeMatch, str) =
-    if iee = ieeMatch andalso Substring.string subs = str
-    then ()
-    else raise Fail "wrong"
-|   ieeeVerify _ = raise Fail "wrong";
-
-ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  1.23X"),
-    {exp = 1, sign = false, class = IEEEReal.NORMAL, digits = [1, 2, 3]}, "X");
-ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  1.23E3X"),
-    {exp = 4, sign = false, class = IEEEReal.NORMAL, digits = [1, 2, 3]}, "X");
-ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  1.23E 3X"),
-    {exp = 1, sign = false, class = IEEEReal.NORMAL, digits = [1, 2, 3]}, "E 3X");
-ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  ~1.23E 3X"),
-    {exp = 1, sign = true, class = IEEEReal.NORMAL, digits = [1, 2, 3]}, "E 3X");
-ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  .23E 3X"),
-    {exp = 0, sign = false, class = IEEEReal.NORMAL, digits = [2, 3]}, "E 3X"); (* Valid, but E 3X isn't part of the number. *)
-verify(not(isSome(IEEEReal.scan Substring.getc (Substring.full "  . 23E 3X")))); (* Not valid. *)
-ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  000.000X"),
-    {exp = 0, sign = false, class = IEEEReal.ZERO, digits = []}, "X");
-verify(not(isSome(IEEEReal.scan Substring.getc (Substring.full "  E2 3X")))); (* Not valid. *)
-ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  0X"),
-    {exp = 0, sign = false, class = IEEEReal.ZERO, digits = []}, "X");
-ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  1X"),
-    {exp = 1, sign = false, class = IEEEReal.NORMAL, digits = [1]}, "X");
-ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  12X"),
-    {exp = 2, sign = false, class = IEEEReal.NORMAL, digits = [1, 2]}, "X");
-ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  0.00X"),
-    {exp = 0, sign = false, class = IEEEReal.ZERO, digits = []}, "X");
-ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  10.X"),
-    {exp = 2, sign = false, class = IEEEReal.NORMAL, digits = [1, 0]}, ".X"); (* Valid. The decimal point is not part of the number. *)
-
 fun timeVerify(SOME(t, subs), tMatch, str) =
     if t = Time.fromMilliseconds tMatch andalso Substring.string subs = str
     then ()

--- a/Tests/Succeed/Test198.ML
+++ b/Tests/Succeed/Test198.ML
@@ -30,8 +30,28 @@ ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  12X"),
     {exp = 2, sign = false, class = IEEEReal.NORMAL, digits = [1, 2]}, "X");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  0.00X"),
     {exp = 0, sign = false, class = IEEEReal.ZERO, digits = []}, "X");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  10"),
+    {exp = 2, sign = false, class = IEEEReal.NORMAL, digits = [1]}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  10.X"),
     {exp = 2, sign = false, class = IEEEReal.NORMAL, digits = [1]}, ".X"); (* Valid. The decimal point is not part of the number. *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "infinity"),
+    {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "+infinity"),
+    {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "-infinity"),
+    {exp = 0, sign = true, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "inf"),
+    {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "+inf"),
+    {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "-inf"),
+    {exp = 0, sign = true, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "nan"),
+    {exp = 0, sign = false, class = IEEEReal.NAN, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "+nan"),
+    {exp = 0, sign = false, class = IEEEReal.NAN, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "-nan"),
+    {exp = 0, sign = true, class = IEEEReal.NAN, digits = []}, "");
 
 
 

--- a/Tests/Succeed/Test198.ML
+++ b/Tests/Succeed/Test198.ML
@@ -1,5 +1,5 @@
 (* Checks for Real.scan, Real.fromString, IEEEReal.scan and IEEEReal.fromString. *)
-fun check true = () | check false = raise Fail "incorrect";
+fun verify true = () | verify false = raise Fail "incorrect";
 
 
 fun ieeeVerify(SOME(iee, subs), ieeMatch, str) =
@@ -35,8 +35,8 @@ ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  10.X"),
 
 
 
-check(not(Real.isFinite(valOf(Real.fromString "infinity"))));
-check(not(Real32.isFinite(valOf(Real32.fromString "infinity"))));
+verify(not(Real.isFinite(valOf(Real.fromString "infinity"))));
+verify(not(Real32.isFinite(valOf(Real32.fromString "infinity"))));
 
-check(Real.isNan(valOf(Real.fromString "nan")));
-check(Real32.isNan(valOf(Real32.fromString "nan")));
+verify(Real.isNan(valOf(Real.fromString "nan")));
+verify(Real32.isNan(valOf(Real32.fromString "nan")));

--- a/Tests/Succeed/Test198.ML
+++ b/Tests/Succeed/Test198.ML
@@ -1,6 +1,40 @@
 (* Checks for Real.scan, Real.fromString, IEEEReal.scan and IEEEReal.fromString. *)
 fun check true = () | check false = raise Fail "incorrect";
 
+
+fun ieeeVerify(SOME(iee, subs), ieeMatch, str) =
+    if iee = ieeMatch andalso Substring.string subs = str
+    then ()
+    else raise Fail "wrong"
+|   ieeeVerify _ = raise Fail "wrong";
+
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  1.23X"),
+    {exp = 1, sign = false, class = IEEEReal.NORMAL, digits = [1, 2, 3]}, "X");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  1.23E3X"),
+    {exp = 4, sign = false, class = IEEEReal.NORMAL, digits = [1, 2, 3]}, "X");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  1.23E 3X"),
+    {exp = 1, sign = false, class = IEEEReal.NORMAL, digits = [1, 2, 3]}, "E 3X");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  ~1.23E 3X"),
+    {exp = 1, sign = true, class = IEEEReal.NORMAL, digits = [1, 2, 3]}, "E 3X");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  .23E 3X"),
+    {exp = 0, sign = false, class = IEEEReal.NORMAL, digits = [2, 3]}, "E 3X"); (* Valid, but E 3X isn't part of the number. *)
+verify(not(isSome(IEEEReal.scan Substring.getc (Substring.full "  . 23E 3X")))); (* Not valid. *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  000.000X"),
+    {exp = 0, sign = false, class = IEEEReal.ZERO, digits = []}, "X");
+verify(not(isSome(IEEEReal.scan Substring.getc (Substring.full "  E2 3X")))); (* Not valid. *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  0X"),
+    {exp = 0, sign = false, class = IEEEReal.ZERO, digits = []}, "X");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  1X"),
+    {exp = 1, sign = false, class = IEEEReal.NORMAL, digits = [1]}, "X");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  12X"),
+    {exp = 2, sign = false, class = IEEEReal.NORMAL, digits = [1, 2]}, "X");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  0.00X"),
+    {exp = 0, sign = false, class = IEEEReal.ZERO, digits = []}, "X");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  10.X"),
+    {exp = 2, sign = false, class = IEEEReal.NORMAL, digits = [1]}, ".X"); (* Valid. The decimal point is not part of the number. *)
+
+
+
 check(not(Real.isFinite(valOf(Real.fromString "infinity"))));
 check(not(Real32.isFinite(valOf(Real32.fromString "infinity"))));
 

--- a/Tests/Succeed/Test198.ML
+++ b/Tests/Succeed/Test198.ML
@@ -40,11 +40,15 @@ ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "+infinity"),
     {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "-infinity"),
     {exp = 0, sign = true, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "~infinity"),
+    {exp = 0, sign = true, class = IEEEReal.INF, digits = []}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "inf"),
     {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "+inf"),
     {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "-inf"),
+    {exp = 0, sign = true, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "~inf"),
     {exp = 0, sign = true, class = IEEEReal.INF, digits = []}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "nan"),
     {exp = 0, sign = false, class = IEEEReal.NAN, digits = []}, "");
@@ -52,7 +56,8 @@ ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "+nan"),
     {exp = 0, sign = false, class = IEEEReal.NAN, digits = []}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "-nan"),
     {exp = 0, sign = true, class = IEEEReal.NAN, digits = []}, "");
-
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "~nan"),
+    {exp = 0, sign = true, class = IEEEReal.NAN, digits = []}, "");
 
 
 verify(not(Real.isFinite(valOf(Real.fromString "infinity"))));

--- a/Tests/Succeed/Test198.ML
+++ b/Tests/Succeed/Test198.ML
@@ -1,0 +1,8 @@
+(* Checks for Real.scan, Real.fromString, IEEEReal.scan and IEEEReal.fromString. *)
+fun check true = () | check false = raise Fail "incorrect";
+
+check(not(Real.isFinite(valOf(Real.fromString "infinity"))));
+check(not(Real32.isFinite(valOf(Real32.fromString "infinity"))));
+
+check(Real.isNan(valOf(Real.fromString "nan")));
+check(Real32.isNan(valOf(Real32.fromString "nan")));

--- a/Tests/Succeed/Test198.ML
+++ b/Tests/Succeed/Test198.ML
@@ -8,6 +8,10 @@ fun ieeeVerify(SOME(iee, subs), ieeMatch, str) =
     else raise Fail "wrong"
 |   ieeeVerify _ = raise Fail "wrong";
 
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  15E~1000"),
+    {exp = ~998, sign = false, class = IEEEReal.NORMAL, digits = [1, 5]}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  1.23E~1"),
+    {exp = 0, sign = false, class = IEEEReal.NORMAL, digits = [1, 2, 3]}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  1.23X"),
     {exp = 1, sign = false, class = IEEEReal.NORMAL, digits = [1, 2, 3]}, "X");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  1.23E3X"),
@@ -34,6 +38,22 @@ ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  10"),
     {exp = 2, sign = false, class = IEEEReal.NORMAL, digits = [1]}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  10.X"),
     {exp = 2, sign = false, class = IEEEReal.NORMAL, digits = [1]}, ".X"); (* Valid. The decimal point is not part of the number. *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " 0.1E~4611686018427387905"), 
+   {exp = 0, sign=false, class = IEEEReal.ZERO, digits = []}, ""); (* Must be rounded to zero instead of overflowing. *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " ~0E4611686018427387905"), 
+   {exp = 0, sign=true, class = IEEEReal.ZERO, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " 0E4611686018427387905"), 
+    {exp = 0, sign=false, class = IEEEReal.ZERO, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " 0.01E4611686018427387904"), 
+    {exp = 4611686018427387903, sign=false, class = IEEEReal.NORMAL, digits = [1]}, "");  (* mustn't be rounded to infinity or overflow, the representation of the exponent fits in an Int *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " 0.0000000000001E4611686018427387915"), 
+    {exp = 4611686018427387903, sign=false, class = IEEEReal.NORMAL, digits = [1]}, ""); (* mustn't be rounded to infinity or overflow, the twelve zeros substract 11 from the stated exponent *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " 1E~4611686018427387905"), 
+    {exp = ~4611686018427387904, sign=false, class = IEEEReal.NORMAL, digits = [1]}, "");  (* mustn't be rounded to zero or overflow, the representation of the exponent fits in an Int *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " 1234567890E~4611686018427387914"), 
+    {exp = ~4611686018427387904, sign=false, class = IEEEReal.NORMAL, digits = [1,2,3,4,5,6,7,8,9]}, "");  (* mustn't be rounded to zero or overflow, the representation of the exponent fits in an Int *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " 1E4611686018427387905"), 
+    {exp = 0, sign=false, class = IEEEReal.INF, digits = []}, ""); 
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "infinity"),
     {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "+infinity"),

--- a/basis/IEEEReal.sml
+++ b/basis/IEEEReal.sml
@@ -168,15 +168,17 @@ struct
 			  )
 			  | ([], _) => (trailing, 0) 
 			  | (lead, []) =>
-			    if (List.last lead) = 0
+			    if (List.last lead) = 0 (* the trailing zeros must be trimmed, return
+						     as exponentInc the original length of the
+						     leading part *)
 			    then (case trimTrailingZeros lead of
 				    trimmed => (trimmed, List.length lead))
 			    else (lead, List.length lead)
-			  | _ => (
-			      case List.@(leading, trailing) of
-				  joined => (joined, List.length leading)
+			  | lead, trail => (
+			      case List.@(lead, trail) of
+				  joined => (joined, List.length lead)
 			  )
-		    (* Get the exponent, returning zero if it doesn't match. *)
+		    (* Get the exponent literal, returning zero if it doesn't match. *)
                     val (exponent, src4) =
                         case getc src3 of
                             NONE => (0, src3)
@@ -195,7 +197,7 @@ struct
                         ([], [], _) => NONE
                       | (_, _, []) =>
                         SOME ({class=ZERO, sign=sign, digits=[], exp=0}, src4)
-                      | _ =>
+                      | (_, _, digits) =>
                             SOME ({class=NORMAL, sign=sign, digits=digits,
                               exp=exponent+exponentInc}, src4)
                 end

--- a/basis/IEEEReal.sml
+++ b/basis/IEEEReal.sml
@@ -166,10 +166,12 @@ struct
 			    case trimLeadingZeros trailing of
 				trimmed => (trimmed, List.length trimmed - List.length trailing)
 			  )
-			  | (x::xs, []) => if (List.last leading) = 0
-					   then (trimTrailingZeros leading, List.length leading)
-					   else (leading, List.length leading)
 			  | ([], _) => (trailing, 0) 
+			  | (lead, []) =>
+			    if (List.last lead) = 0
+			    then (case trimTrailingZeros lead of
+				    trimmed => (trimmed, List.length lead))
+			    else (lead, List.length lead)
 			  | _ => (
 			      case List.@(leading, trailing) of
 				  joined => (joined, List.length leading)

--- a/basis/Real.sml
+++ b/basis/Real.sml
@@ -1,7 +1,7 @@
 (*
     Title:      Standard Basis Library: Real Signature and structure.
     Author:     David Matthews
-    Copyright   David Matthews 2000, 2005, 2008, 2016-18
+    Copyright   David Matthews 2000, 2005, 2008, 2016-18, 2023
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -413,104 +413,19 @@ struct
         val toString = fmt (GEN NONE)
     end
 
-
+    (* Define these in terms of IEEEReal.scan since that deals with all the
+       special cases. *)
     fun scan getc src =
-    let
-        (* Return a list of digits. *)
-        fun getdigits inp src =
-            case getc src of
-                NONE => (List.rev inp, src)
-              | SOME(ch, src') =>
-                    if ch >= #"0" andalso ch <= #"9"
-                    then getdigits ((Char.ord ch - Char.ord #"0") :: inp) src'
-                    else (List.rev inp, src)
-
-        (* Read an unsigned integer.  Returns NONE if no digits have been read. *)
-        fun getNumber sign digits acc src =
-            case getc src of
-                NONE => if digits = 0 then NONE else SOME(if sign then ~acc else acc, src)
-              | SOME(ch, src') =>
-                    if ch >= #"0" andalso ch <= #"9"
-                    then getNumber sign (digits+1) (acc*10 + Char.ord ch - Char.ord #"0") src'
-                    else if digits = 0 then NONE else SOME(if sign then ~acc else acc, src')
-
-        (* Return the signed exponent. *)
-        fun getExponent src =
-            case getc src of
-                NONE => NONE
-              | SOME(ch, src') =>
-                if ch = #"+"
-                then getNumber false 0 0 src'
-                else if ch = #"-" orelse ch = #"~"
-                then getNumber true 0 0 src'
-                else getNumber false 0 0 src
-
-        fun read_number sign src =
-            case getc src of
-                NONE => NONE
-              | SOME(ch, _) =>
-                    if not (ch >= #"0" andalso ch <= #"9" orelse ch = #".")
-                    then NONE (* Bad *)
-                    else (* Digits or decimal. *)
-                    let
-                        (* Get the digits before the decimal point (if any) *)
-                        val (intPart, srcAfterDigs) = getdigits [] src
-                        (* Get the digits after the decimal point (if any).
-                           If there is a decimal point we only accept it if
-                           there is at least one digit after it. *)
-                        val (decimals, srcAfterMant) =
-                            case getc srcAfterDigs of
-                                NONE => ([], srcAfterDigs)
-                             |  SOME (#".", srcAfterDP) =>
-                                    ( (* Check that the next character is a digit. *)
-                                    case getc srcAfterDP of
-                                        NONE => ([], srcAfterDigs)
-                                      | SOME(ch, _) =>
-                                            if ch >= #"0" andalso ch <= #"9"
-                                            then getdigits [] srcAfterDP
-                                            else ([], srcAfterDigs)
-                                    )
-                             |  SOME (_, _) => ([], srcAfterDigs)
-                        (* The exponent is optional.  If it doesn't form a valid
-                           exponent we return zero as the value and the
-                           continuation is the beginning of the "exponent". *)
-                        val (exponent, srcAfterExp) =
-                            case getc srcAfterMant of
-                                NONE => (0, srcAfterMant)
-                             |  SOME (ch, src'''') =>
-                                if ch = #"e" orelse ch = #"E"
-                                then 
-                                    (
-                                    case getExponent src'''' of
-                                        NONE => (0, srcAfterMant)
-                                      | SOME x => x 
-                                    )
-                                else (0, srcAfterMant)
-                        (* Generate a decimal representation ready for conversion.
-                           We don't bother to strip off leading or trailing zeros. *)
-                        val decimalRep = {class=NORMAL, sign=sign,
-                                digits=List.@(intPart, decimals),
-                                exp=exponent + List.length intPart}
-                    in
-                        case fromDecimal decimalRep of
-                           SOME r => SOME(r, srcAfterExp)
-                         | NONE => NONE
-                    end
-    in
-        case getc src of
+        case IEEEReal.scan getc src of
             NONE => NONE
-         |  SOME(ch, src') =>
-            if Char.isSpace ch (* Skip white space. *)
-            then scan getc src' (* Recurse *)
-            else if ch = #"+" (* Remove the + sign *)
-            then read_number false src'
-            else if ch = #"-" orelse ch = #"~"
-            then read_number true src'
-            else (* See if it's a valid digit. *)
-                read_number false src
-    end
-    
-    val fromString = StringCvt.scanString scan
+        |   SOME (ieer, rest) =>
+            (
+                case fromDecimal ieer of
+                    NONE => NONE
+                |   SOME r => SOME(r, rest)
+            )
+
+    val fromString = Option.composePartial (fromDecimal, IEEEReal.fromString)
 
     (* Converter to real values. This replaces the basic conversion
        function for reals installed in the bootstrap process.

--- a/libpolyml/processes.h
+++ b/libpolyml/processes.h
@@ -134,7 +134,7 @@ public:
     virtual void addProfileCount(POLYUNSIGNED words) = 0;
 
     // Functions called before and after an RTS call.
-    virtual void PreRTSCall(void) {}
+    virtual void PreRTSCall(void) { saveVec.init(); }
     virtual void PostRTSCall(void) {}
 
     SaveVec     saveVec;


### PR DESCRIPTION
This commit fixes some incorrect behaviors of `IEEEReal.scan` as described in #182 , cases 1, 2, and 3. Namely:

1. Complete removal of trailing zeros: cases such as `IEEEReal.fromString "10.0"` now return `SOME {class = NORMAL, digits = [1], exp = 2, sign = false}.` instead of `... digits = [1, 0] ...`.
2. Complete removal of leading zeros: cases such as `IEEEReal.fromString "0.01"` now return  `SOME {class = NORMAL, digits = [1], exp = ~1, sign = false}` instead of `... digits = [0, 1], exp = 0 ...`.
3. Numbers with base 0 never overflow: cases such as `IEEEReal.fromString "0e4611686018427387904"` return `SOME {class = ZERO, digits = [], exp = 0, sign = false}` instead of overflowing.

I'm quite new to SML, so my code may not be the most idiomatic. Any feedback will be greatly appreciated.
