### PR TITLE
Fix behavior of `IEEEReal.scan`

### DIFF
--- a/Tests/Succeed/Test198.ML
+++ b/Tests/Succeed/Test198.ML
@@ -30,8 +30,28 @@ ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  12X"),
     {exp = 2, sign = false, class = IEEEReal.NORMAL, digits = [1, 2]}, "X");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  0.00X"),
     {exp = 0, sign = false, class = IEEEReal.ZERO, digits = []}, "X");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  10"),
+    {exp = 2, sign = false, class = IEEEReal.NORMAL, digits = [1]}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  10.X"),
     {exp = 2, sign = false, class = IEEEReal.NORMAL, digits = [1]}, ".X"); (* Valid. The decimal point is not part of the number. *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "infinity"),
+    {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "+infinity"),
+    {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "-infinity"),
+    {exp = 0, sign = true, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "inf"),
+    {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "+inf"),
+    {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "-inf"),
+    {exp = 0, sign = true, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "nan"),
+    {exp = 0, sign = false, class = IEEEReal.NAN, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "+nan"),
+    {exp = 0, sign = false, class = IEEEReal.NAN, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "-nan"),
+    {exp = 0, sign = true, class = IEEEReal.NAN, digits = []}, "");
 
 
 

--- a/Tests/Succeed/Test198.ML
+++ b/Tests/Succeed/Test198.ML
@@ -40,11 +40,15 @@ ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "+infinity"),
     {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "-infinity"),
     {exp = 0, sign = true, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "~infinity"),
+    {exp = 0, sign = true, class = IEEEReal.INF, digits = []}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "inf"),
     {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "+inf"),
     {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "-inf"),
+    {exp = 0, sign = true, class = IEEEReal.INF, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "~inf"),
     {exp = 0, sign = true, class = IEEEReal.INF, digits = []}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "nan"),
     {exp = 0, sign = false, class = IEEEReal.NAN, digits = []}, "");
@@ -52,7 +56,8 @@ ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "+nan"),
     {exp = 0, sign = false, class = IEEEReal.NAN, digits = []}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "-nan"),
     {exp = 0, sign = true, class = IEEEReal.NAN, digits = []}, "");
-
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "~nan"),
+    {exp = 0, sign = true, class = IEEEReal.NAN, digits = []}, "");
 
 
 verify(not(Real.isFinite(valOf(Real.fromString "infinity"))));

--- a/Tests/Succeed/Test198.ML
+++ b/Tests/Succeed/Test198.ML
@@ -8,6 +8,10 @@ fun ieeeVerify(SOME(iee, subs), ieeMatch, str) =
     else raise Fail "wrong"
 |   ieeeVerify _ = raise Fail "wrong";
 
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  15E~1000"),
+    {exp = ~998, sign = false, class = IEEEReal.NORMAL, digits = [1, 5]}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  1.23E~1"),
+    {exp = 0, sign = false, class = IEEEReal.NORMAL, digits = [1, 2, 3]}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  1.23X"),
     {exp = 1, sign = false, class = IEEEReal.NORMAL, digits = [1, 2, 3]}, "X");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  1.23E3X"),
@@ -34,6 +38,22 @@ ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  10"),
     {exp = 2, sign = false, class = IEEEReal.NORMAL, digits = [1]}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "  10.X"),
     {exp = 2, sign = false, class = IEEEReal.NORMAL, digits = [1]}, ".X"); (* Valid. The decimal point is not part of the number. *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " 0.1E~4611686018427387905"), 
+   {exp = 0, sign=false, class = IEEEReal.ZERO, digits = []}, ""); (* Must be rounded to zero instead of overflowing. *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " ~0E4611686018427387905"), 
+   {exp = 0, sign=true, class = IEEEReal.ZERO, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " 0E4611686018427387905"), 
+    {exp = 0, sign=false, class = IEEEReal.ZERO, digits = []}, "");
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " 0.01E4611686018427387904"), 
+    {exp = 4611686018427387903, sign=false, class = IEEEReal.NORMAL, digits = [1]}, "");  (* mustn't be rounded to infinity or overflow, the representation of the exponent fits in an Int *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " 0.0000000000001E4611686018427387915"), 
+    {exp = 4611686018427387903, sign=false, class = IEEEReal.NORMAL, digits = [1]}, ""); (* mustn't be rounded to infinity or overflow, the twelve zeros substract 11 from the stated exponent *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " 1E~4611686018427387905"), 
+    {exp = ~4611686018427387904, sign=false, class = IEEEReal.NORMAL, digits = [1]}, "");  (* mustn't be rounded to zero or overflow, the representation of the exponent fits in an Int *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " 1234567890E~4611686018427387914"), 
+    {exp = ~4611686018427387904, sign=false, class = IEEEReal.NORMAL, digits = [1,2,3,4,5,6,7,8,9]}, "");  (* mustn't be rounded to zero or overflow, the representation of the exponent fits in an Int *)
+ieeeVerify(IEEEReal.scan Substring.getc (Substring.full " 1E4611686018427387905"), 
+    {exp = 0, sign=false, class = IEEEReal.INF, digits = []}, ""); 
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "infinity"),
     {exp = 0, sign = false, class = IEEEReal.INF, digits = []}, "");
 ieeeVerify(IEEEReal.scan Substring.getc (Substring.full "+infinity"),

--- a/basis/IEEEReal.sml
+++ b/basis/IEEEReal.sml
@@ -168,15 +168,17 @@ struct
 			  )
 			  | ([], _) => (trailing, 0) 
 			  | (lead, []) =>
-			    if (List.last lead) = 0
+			    if (List.last lead) = 0 (* the trailing zeros must be trimmed, return
+						     as exponentInc the original length of the
+						     leading part *)
 			    then (case trimTrailingZeros lead of
 				    trimmed => (trimmed, List.length lead))
 			    else (lead, List.length lead)
-			  | _ => (
-			      case List.@(leading, trailing) of
-				  joined => (joined, List.length leading)
+			  | lead, trail => (
+			      case List.@(lead, trail) of
+				  joined => (joined, List.length lead)
 			  )
-		    (* Get the exponent, returning zero if it doesn't match. *)
+		    (* Get the exponent literal, returning zero if it doesn't match. *)
                     val (exponent, src4) =
                         case getc src3 of
                             NONE => (0, src3)
@@ -195,7 +197,7 @@ struct
                         ([], [], _) => NONE
                       | (_, _, []) =>
                         SOME ({class=ZERO, sign=sign, digits=[], exp=0}, src4)
-                      | _ =>
+                      | (_, _, digits) =>
                             SOME ({class=NORMAL, sign=sign, digits=digits,
                               exp=exponent+exponentInc}, src4)
                 end

--- a/basis/IEEEReal.sml
+++ b/basis/IEEEReal.sml
@@ -166,10 +166,12 @@ struct
 			    case trimLeadingZeros trailing of
 				trimmed => (trimmed, List.length trimmed - List.length trailing)
 			  )
-			  | (x::xs, []) => if (List.last leading) = 0
-					   then (trimTrailingZeros leading, List.length leading)
-					   else (leading, List.length leading)
 			  | ([], _) => (trailing, 0) 
+			  | (lead, []) =>
+			    if (List.last lead) = 0
+			    then (case trimTrailingZeros lead of
+				    trimmed => (trimmed, List.length lead))
+			    else (lead, List.length lead)
 			  | _ => (
 			      case List.@(leading, trailing) of
 				  joined => (joined, List.length leading)


### PR DESCRIPTION
This PR fixes #182  , some incorrect behaviors of `IEEEReal.scan`. Namely:

- Complete removal of trailing zeros: cases such as `IEEEReal.fromString "10.0"` now return `SOME {class = NORMAL, digits = [1], exp = 2, sign = false}` instead of `... digits = [1, 0] ....`
- Complete removal of leading zeros: cases such as `IEEEReal.fromString "0.01"` now return `SOME {class = NORMAL, digits = [1], exp = ~1, sign = false}` instead of `... digits = [0, 1], exp = 0 ....`
- Numbers with base 0 never overflow: cases such as `IEEEReal.fromString "0e4611686018427387904"` return `SOME {class = ZERO, digits = [], exp = 0, sign = false}` instead of overflowing.
- Numbers with an exponent that can be represented but whose exponent literal would overflow if it were an integer literal, don't overflow anymore: cases such as `IEEEReal.fromString "1E~4611686018427387905"` return `SOME {exp = ~4611686018427387904, sign=false, class = NORMAL, digits = [1]}` instead of overflowing. Same for the equivalent case with positive exponent literals.
- Numbers with an overflowing negative exponent are rounded to zero: cases such as `IEEEReal.fromString "0.1E~4611686018427387905"` return `SOME {exp = 0, sign=false, class = ZERO, digits = []}` instead of overflowing.
- Numbers with an overflowing positive exponent are rounded to infinity: cases such as `IEEEReal.fromString "1E4611686018427387905"` return `SOME {exp = 0, sign=false, class = INF, digits = []}` instead of overflowing.

I have added several test cases for the above described situations, plus some more for cases that already were working correctly. I have also checked that this fixes pass the rest of the regression test suite.

I'm quite new to SML, so my code may not be the most idiomatic. Any feedback will be greatly appreciated.