### PR TITLE
Properly initialize unknown fields in `struct tm`.

### DIFF
--- a/libpolyml/timing.cpp
+++ b/libpolyml/timing.cpp
@@ -406,7 +406,7 @@ POLYUNSIGNED PolyTimingConvertDateStuct(POLYUNSIGNED threadId, POLYUNSIGNED arg)
     Handle result = 0;
 
     try {
-        struct  tm time;
+        struct  tm time = {0};
         char* format, buff[2048];
         Handle  resString;
         /* Get the format string. */


### PR DESCRIPTION
The uninitialized fields were causing a segfault on Linux+glibc, when `Date.fmt s` was called and `s` contained `%Z` (or anything that expands to `%Z`, such as `%c` under some locales).

Fixes #189.

Note: I tried adding a test case, but unfortunately I could not reproduce this bug as part of the test suite.

My guess is that when running the test suite, the C stack expands to an area that only contains zeros instead of garbage data.

If the stack contains zeros, then the uninitialized `tm_zone` field would be a NULL pointer, which glibc would process correctly, instead of an invalid pointer which would cause the crash.

However, I have not verified this theory. I did verify that the patch fixes the issue, though.