### PR TITLE
Fix #200: Word.toInt not raising Overflow in some cases

### DIFF
--- a/Tests/Succeed/Test202.ML
+++ b/Tests/Succeed/Test202.ML
@@ -1,0 +1,18 @@
+(* Conversion bug from Word types to Int where Word.toInt fails to raise
+   overflow when the size of the word is double the maximum integer
+   representable. Github issue #200. *)
+
+case Int.precision of
+    NONE => () (* bug not present in this case *)
+  | SOME p =>
+    let
+        val maxInt = Option.getOpt(Int.maxInt, 0)
+        val large = if maxInt = 0
+                    then raise Fail "Unexpected maxInt"
+                    else ((LargeInt.fromInt maxInt) + 1) * 2
+        val _ = (LargeWord.toInt o LargeWord.fromLargeInt) large
+    in
+        raise Fail "Bad"
+    end
+    handle Overflow => () (* overflow expected *)
+         | exn => raise exn

--- a/basis/LargeWord.sml
+++ b/basis/LargeWord.sml
@@ -180,8 +180,8 @@ in
         and fromLargeInt = wordFromLargeInt
 
         (* Conversion to signed integer is simple. *)
-        val toIntX: word->int = RunCall.unsafeCast
-        and toLargeIntX: word -> LargeInt.int = RunCall.unsafeCast
+	val toLargeIntX: word -> LargeInt.int = RunCall.unsafeCast
+        val toIntX = Int.fromLarge o toLargeIntX
         
         (* Conversion to unsigned integer has to treat values with the sign bit
            set specially. *)
@@ -194,10 +194,7 @@ in
 
         (* If int is arbitrary precision we just convert it
            otherwise we have to check the range. *)
-        val toInt =
-            case Int.maxInt of
-                NONE => (fn x => LargeInt.toInt(toLargeInt x))
-            |   SOME m => (fn x => if x > fromInt m then raise Overflow else toIntX x)
+        val toInt =  Int.fromLarge o toLargeInt
 
         fun scan radix getc src =
             case scanWord radix getc src of
@@ -284,15 +281,8 @@ in
             then fromLargeInt(LargeInt.fromInt i)
             else Word.toLargeWordX(Word.fromInt i)
 
-        and toInt(w: word): int =
-            if Bootstrap.intIsArbitraryPrecision
-            then LargeInt.toInt(toLargeInt w)
-            else Word.toInt(Word.fromLargeWord w)
-            
-        and toIntX(w: word): int =
-            if Bootstrap.intIsArbitraryPrecision
-            then LargeInt.toInt(toLargeIntX w)
-            else Word.toIntX(Word.fromLargeWord w)
+        val toInt = Int.fromLarge o toLargeInt
+        val toIntX = Int.fromLarge o toLargeIntX
 
         fun scan radix getc src =
             case scanWord radix getc src of


### PR DESCRIPTION
Fixes the behavior where a word, if of size equal or larger than double the maximum integer representable, wrapped around instead of overflowing when converting to Int