### PR TITLE
Add "-ld_classic" into LDFLAGS if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,19 @@ AC_CANONICAL_HOST
 # building for something else.
 AC_CHECK_DECL([_WIN32], [poly_native_windows=yes], [poly_native_windows=no])
 
+# In recent macOS (with Xcode/clang 15+), the linker option -ld_classic must be
+# used to build Poly/ML. Here we just check if this linker option is available,
+# without further checking if we are actually in macOS.
+#
+# The variable "use_classic_linker" defined here is later used to define the
+# AM_CONDITIONAL called CLASSIC_LINKER, which is further used when generating
+# the "polyc" script. -- Chun Tian (binghe), Jul 23, 2024
+#
+AX_CHECK_LINK_FLAG([-ld_classic],
+    [LDFLAGS="$LDFLAGS -ld_classic"
+     use_classic_linker=yes],
+    [use_classic_linker=no])
+
 # If we are building on cygwin or mingw we need to give the -no-defined flag to
 # build a DLL.  We also have to use Windows calling conventions rather than
 # SysV on 64-bit.
@@ -544,6 +557,9 @@ AM_CONDITIONAL([WINDOWSCALLCONV], [test "$poly_use_windowscc" = yes])
 AM_CONDITIONAL([NATIVE_WINDOWS], [test "$poly_native_windows" = yes])
 AM_CONDITIONAL([NO_UNDEFINED], [test "$poly_no_undefined" = yes])
 AM_CONDITIONAL([WINDOWSGUI], [test x$poly_windows_enablegui = xtrue])
+
+# This conditional will be later use when generating "polyc"
+AM_CONDITIONAL([CLASSIC_LINKER], [test "$use_classic_linker" = yes])
 
 # If we're building only the static version of libpolyml
 # then polyc and polyml.pc have to include the dependent libraries.

--- a/m4/ax_check_link_flag.m4
+++ b/m4/ax_check_link_flag.m4
@@ -1,0 +1,53 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_check_link_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_LINK_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the linker or gives an error.
+#   (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the linker's default flags
+#   when the check is done.  The check is thus made with the flags: "LDFLAGS
+#   EXTRA-FLAGS FLAG".  This can for example be used to force the linker to
+#   issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_LINK_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,COMPILE}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_LINK_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_ldflags_$4_$1])dnl
+AC_CACHE_CHECK([whether the linker accepts $1], CACHEVAR, [
+  ax_check_save_flags=$LDFLAGS
+  LDFLAGS="$LDFLAGS $4 $1"
+  AC_LINK_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  LDFLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_LINK_FLAGS

--- a/polyc.in
+++ b/polyc.in
@@ -20,6 +20,9 @@ COMPILER="${DEFAULT_COMPILER}"
 @NATIVE_WINDOWS_TRUE@@WINDOWSGUI_TRUE@EXTRALDFLAGS+=" -mwindows"
 @NATIVE_WINDOWS_TRUE@@WINDOWSGUI_FALSE@EXTRALDFLAGS+=" -mconsole"
 
+# Extra options for macOS
+@CLASSIC_LINKER_TRUE@EXTRALDFLAGS="-ld_classic"
+
 @NATIVE_WINDOWS_TRUE@SUFFIX="obj"
 @NATIVE_WINDOWS_FALSE@SUFFIX="o"
 
@@ -40,9 +43,9 @@ link()
 {
     if [ X"$2" = "X" ]
     then
-        "${LINK}" ${EXTRALDFLAGS} ${CFLAGS} "$1" "-L${LIBDIR}" "-Wl,-rpath,${LIBDIR}" -lpolymain -lpolyml ${LIBS}
+        ${LINK} ${EXTRALDFLAGS} ${CFLAGS} "$1" "-L${LIBDIR}" "-Wl,-rpath,${LIBDIR}" -lpolymain -lpolyml ${LIBS}
     else
-        "${LINK}" ${EXTRALDFLAGS} ${CFLAGS} "$1" -o "$2" "-L${LIBDIR}" "-Wl,-rpath,${LIBDIR}" -lpolymain -lpolyml ${LIBS}
+        ${LINK} ${EXTRALDFLAGS} ${CFLAGS} "$1" -o "$2" "-L${LIBDIR}" "-Wl,-rpath,${LIBDIR}" -lpolymain -lpolyml ${LIBS}
     fi
 }
 


### PR DESCRIPTION
Hi,

The purpose of this PR is to fix Poly/ML building issues in recent versions of macOS (see #192 and #194). The idea is that, whenever the linker flag `-ld_classic` is supported (no matter if this is on macOS or not), it's added into `LDFLAGS`, not only for building Poly/ML itself, but also part of the `polyc` script.  I have spent a little time learning `autoconf` and your existing code in `configure.in`.

The detection of linker flags is done by a M4 macro called `AX_CHECK_LINK_FLAG` (copied from GNU autotools-archive to `m4/ax_check_link_flag.m4`):
```
AX_CHECK_LINK_FLAG([-ld_classic],
    [LDFLAGS="$LDFLAGS -ld_classic"
     use_classic_linker=yes],
    [use_classic_linker=no])
```
Beside pushing `-ld_classic` into environment variable `LDFLAGS` for building Poly/ML itslef, the above defined variable `use_classic_linker` is further used to define a "AM_CONDITIONAL" called `CLASSIC_LINKER`:

```
AM_CONDITIONAL([CLASSIC_LINKER], [test "$use_classic_linker" = yes])
```

Finally, in `polyc.in`, an extra line of `EXTRALDFLAGS="-ld_classic"` is added when calling the linker.
```
# Extra options for macOS
@CLASSIC_LINKER_TRUE@EXTRALDFLAGS="-ld_classic"
```

Note also that, sometimes in the generated `polyc` script, the value of `LINK` is something like `/usr/bin/clang++ -std=gnu++11` (the compiler execution and another flags, separated by a whitespace).  I think this is a behavior of higher versions of autoconf.  In this case you cannot write `"${LINK}" ${LDFLAGS} ...` to call the linker, because this whole string `"${LINK}"` will be treated as a single filename, which does not exist then...  I don't know what will happen if the compiler itself is installed in a path which itself contains directory names with spaces, but this case should be rare. A obvious workaround of this issue is to simply delete the double-quotes around `${LINK}`. This is exactly what I did.

P.S. I actually don't know how to run the `AX_CHECK_LINK_FLAG` check in only macOS, but the current way should be safe for other OSs. Anyway, feel free to further modify my solution.

--Chun
