### PR TITLE
Fix PolyML.make infinite recursion when called with an absolute path.

### DIFF
--- a/basis/FinalPolyML.sml
+++ b/basis/FinalPolyML.sml
@@ -772,13 +772,18 @@ local
             open OS.FileSys
             val {dir, file} = OS.Path.splitDirFile fileName
             val dirName = if dir = "" then OS.Path.currentArc else dir
-            val direc = openDir dirName
             fun readAll () =
-                case readDir direc of
-                    NONE => false
-                |   SOME f => f = file orelse readAll() 
+                let
+                    val direc = openDir dirName
+                    fun read () =
+                        case readDir direc of
+                            NONE => false
+                        |   SOME f => f = file orelse read ()
+                in
+                    read () before closeDir direc
+                end
         in
-            ((dir = "" orelse reallyexists dir) andalso readAll()) before closeDir direc
+            (OS.Path.isRoot dir orelse dir = "" orelse reallyexists dir) andalso readAll()
         end
 
         fun findFileTuple _                   [] = NONE


### PR DESCRIPTION
`OS.Path.splitDirFile` returns `/` when called with `/`, so the `dir = ""` condition is never true if the file name is absolute. Combined with the dir being opened before the recursive call and only closed after the call has completed, this makes `reallyexists` loop infinitely until a SysErr is raised:

    $ poly --eval 'PolyML.make "/"'
    Poly/ML 5.9.1 Release
    Exception- SysErr ("Too many open files", SOME EMFILE) raised
    $