### PR TITLE
Fix "polyc" when ${LINK} contains spaces

### DIFF
--- a/polyc.in
+++ b/polyc.in
@@ -40,9 +40,9 @@ link()
 {
     if [ X"$2" = "X" ]
     then
-        "${LINK}" ${EXTRALDFLAGS} ${CFLAGS} "$1" "-L${LIBDIR}" "-Wl,-rpath,${LIBDIR}" -lpolymain -lpolyml ${LIBS}
+        ${LINK} ${EXTRALDFLAGS} ${CFLAGS} "$1" "-L${LIBDIR}" "-Wl,-rpath,${LIBDIR}" -lpolymain -lpolyml ${LIBS}
     else
-        "${LINK}" ${EXTRALDFLAGS} ${CFLAGS} "$1" -o "$2" "-L${LIBDIR}" "-Wl,-rpath,${LIBDIR}" -lpolymain -lpolyml ${LIBS}
+        ${LINK} ${EXTRALDFLAGS} ${CFLAGS} "$1" -o "$2" "-L${LIBDIR}" "-Wl,-rpath,${LIBDIR}" -lpolymain -lpolyml ${LIBS}
     fi
 }
 


### PR DESCRIPTION
Hi,

thanks again for fixing the macOS linker/exporter issue (7f548c30), but there's still the remaining issue in `polyc` script, where the generated `${LINK}` contains spaces and cannot be called as a valid execution. This PR fixes it by removing the surrounding double-quotes.

P. S. I hope a new minor release can be made after this fix, so that the prebuilt polyml packages on macOS (MacPorts and Homebrew, etc.) can be fixed by naturally moving to a new version. (Currently they are broken on recent macOS versions due the already fixed linker/exporter issue.) Having working prebuilt PolyML packages will greatly ease many potential users.

Regards,

Chun