### PR TITLE
Refactor parsetreesig

### DIFF
--- a/mlsource/MLCompiler/PARSETREESIG.sml
+++ b/mlsource/MLCompiler/PARSETREESIG.sml
@@ -76,27 +76,15 @@ sig
     val mkCond   : parsetree * parsetree * parsetree * location -> parsetree;
     val mkTupleTree : parsetree list * location -> parsetree;
 
+    type bindEnv =
+        { lookup: string -> typeVarForm option,
+          apply: (string * typeVarForm -> unit) -> unit }
+
     val mkValDeclaration :
-       valbind list *
-       {
-         lookup: string -> typeVarForm option,
-         apply: (string * typeVarForm -> unit) -> unit
-       } *
-       {
-         lookup: string -> typeVarForm option,
-         apply: (string * typeVarForm -> unit) -> unit
-       } * location ->  parsetree;
+        valbind list * bindEnv * bindEnv * location ->  parsetree;
 
     val mkFunDeclaration :
-       fvalbind list *
-       {
-         lookup: string -> typeVarForm option,
-         apply: (string * typeVarForm -> unit) -> unit
-       } *
-       {
-         lookup: string -> typeVarForm option,
-         apply: (string * typeVarForm -> unit) -> unit
-       } * location ->  parsetree;
+        fvalbind list * bindEnv * bindEnv * location ->  parsetree;
 
     val mkOpenTree : structureIdentForm list * location -> parsetree;
     val mkStructureIdent : string * location -> structureIdentForm;

--- a/mlsource/MLCompiler/ParseTree/PARSE_TREE.ML
+++ b/mlsource/MLCompiler/ParseTree/PARSE_TREE.ML
@@ -127,6 +127,10 @@ struct
         }
        
     fun mkTupleTree(fields, location) = TupleTree { fields=fields, location=location, expType = ref EmptyType }
+
+    type bindEnv =
+        { lookup: string -> typeVarForm option,
+          apply: (string * typeVarForm -> unit) -> unit }
     
     fun mkValDeclaration (dec, explicit, implicit, location) : parsetree = 
         ValDeclaration 


### PR DESCRIPTION
Tiny refactor of `PARSETREESIG.sml` for more uniform indentation and whitespace and to reduce type duplication.