### PR TITLE
Use C++11 for compilation

### DIFF
--- a/libpolyml/Makefile.am
+++ b/libpolyml/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS=foreign
 
 moduledir = @moduledir@
 
-AM_CPPFLAGS = $(CFLAGS) $(OSFLAG) $(GIT_VERSION) -Wall -DMODULEDIR=\"$(moduledir)\"
+AM_CPPFLAGS = -std=c++11 $(CFLAGS) $(OSFLAG) $(GIT_VERSION) -Wall -DMODULEDIR=\"$(moduledir)\"
 AM_CFLAGS = $(CFLAGS) $(OSFLAG) $(GIT_VERSION) -Wall -fno-strict-aliasing
 AM_ASFLAGS = $(OSFLAG)
 AM_CCASFLAGS = $(OSFLAG)

--- a/libpolyml/Makefile.in
+++ b/libpolyml/Makefile.in
@@ -460,7 +460,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign
-AM_CPPFLAGS = $(CFLAGS) $(OSFLAG) $(GIT_VERSION) -Wall \
+AM_CPPFLAGS = -std=c++11 $(CFLAGS) $(OSFLAG) $(GIT_VERSION) -Wall \
 	-DMODULEDIR=\"$(moduledir)\" $(am__append_2)
 AM_CFLAGS = $(CFLAGS) $(OSFLAG) $(GIT_VERSION) -Wall -fno-strict-aliasing
 AM_ASFLAGS = $(OSFLAG)


### PR DESCRIPTION
Hi @dcjm,
my understanding is that, as of now, the compilation of the `libpolyml` runtime uses whichever C++ version is the default for the compiler. I propose to choose a C++ version to be the official one used in the project. This would have the following advantages:

- It would explicitly specify and document which features of the C++ language and standard library can be used in the implementation of `libpolyml`.
- It would reduce the probability of incompatibility if the C++ compiler uses an incompatible version by default.
- It would enable small simplifications, as some implementation specific features get standardize (e.g., fixed width integer types, concurrency library, file system library).

I successfully tested compiling `libpolyml` with C++14 to start the discussion; I propose this version as a compromise between being modern (i.e., C++11 and following aim to modernize the language) and being conservative (i.e., it is 11 years old and compilers are readily available).

What do you think of the general idea and the choice of C++14?