### PR TITLE
Simplify an indirect on a raise

### DIFF
--- a/mlsource/MLCompiler/CodeTree/CodetreeFunctions.ML
+++ b/mlsource/MLCompiler/CodeTree/CodetreeFunctions.ML
@@ -410,6 +410,7 @@ struct
        side-effects/raise exceptions e.g. #1 (1, raise Fail "bad") *)
     local
         fun mkIndirect isVar (addr, base as Constnt _) = findEntryInBlock(base, addr, isVar)
+        |   mkIndirect isVar (addr, base as Raise _) = base
         |   mkIndirect isVar (addr, base) =
                 Indirect {base = base, offset = addr, indKind = if isVar then IndVariant else IndTuple}
     


### PR DESCRIPTION
RAISE(Local0)[0] can be simplified into
RAISE(Local0)
see this reproducer which generates such code
exception FOO
fun repro b x y = let val x = (if b then (x,y) else raise FOO) handle FOO => raise FOO
                  in #1 x end