### PR TITLE
Add function to get exported object file extension

### DIFF
--- a/basis/InitialPolyML.ML
+++ b/basis/InitialPolyML.ML
@@ -68,6 +68,8 @@ in
             and exportPortable(filename, f) = callExportP(filename, runFunction f)
         end
         
+        val exportedObjectFileExt: unit -> string = RunCall.rtsCallFull0 "PolyExportedObjectFileExt"
+
         local
             (* shareCommonData needs to be able to take a value of any type. *)
             val callShare: word -> unit = RunCall.rtsCallFull1 "PolyShareCommonData"


### PR DESCRIPTION
PolyMLB exports an object file and runs the linker from SML, calling `polyc` via `OS.Process.system`.  This requires PolyMLB to know the system-dependent object file extension, which will be appended by `PolyML.export` if the object file name does not already have that extension.  Currently, PolyMLB assumes the extension of an object file is `o` which causes an issue on Windows where it is `obj`.  This pull request adds a function to the PolyML structure to return the object file extension for the platform.  The function is currently called `exportedObjectFileExt` but I am happy for this to be changed.

Perhaps there is a better way to achieve this but I thought I would propose this function for now.