### PR TITLE
Add support for record update

### DIFF
--- a/Tests/Fail/TestRecordUpdate001.ML
+++ b/Tests/Fail/TestRecordUpdate001.ML
@@ -1,0 +1,8 @@
+(* Record update must be enabled manually. *)
+
+let
+    val r = {a = 10, b = [20, 21, 22], c = "30"}
+    val r' = {r with a = 11}
+in
+    #a r' = 11 andalso #b r' = #b r andalso #c r' = #c r
+end;

--- a/Tests/Fail/TestRecordUpdate002.ML
+++ b/Tests/Fail/TestRecordUpdate002.ML
@@ -1,0 +1,9 @@
+(* Record update requires a base of record type. *)
+
+PolyML.Compiler.languageExtensions := true;
+
+let
+    val r : int = 10
+in
+    {r with a = 11}
+end;

--- a/Tests/Fail/TestRecordUpdate003.ML
+++ b/Tests/Fail/TestRecordUpdate003.ML
@@ -1,0 +1,4 @@
+PolyML.Compiler.languageExtensions := true;
+
+(* Can't find a fixed record type *)
+fun setA r x = {r where a = x};

--- a/Tests/Succeed/TestRecordUpdate001.ML
+++ b/Tests/Succeed/TestRecordUpdate001.ML
@@ -113,3 +113,14 @@ end = struct
     fun getA{a,...} = a
     fun setA x y = {x where a = y}
 end;
+
+(* The base record gets evaluated only once *)
+let
+    val x = ref 1
+    fun mkRec () = {a= !x, b= !x, c= !x, d= !x} before x := !x+1
+    val r = {(mkRec()) where a = 0, b = 0};
+    val correct : bool =
+        r = {a = 0, b = 0, c = 1, d = 1} andalso !x = 2
+in
+    if correct then () else raise Fail "Record update: base evaluation"
+end;

--- a/Tests/Succeed/TestRecordUpdate001.ML
+++ b/Tests/Succeed/TestRecordUpdate001.ML
@@ -1,0 +1,115 @@
+(* Record update can be enabled manually. *)
+
+PolyML.Compiler.languageExtensions := true;
+
+(* Basic usage. *)
+let
+    val r = {a = 0, b = [], c = ""}
+    val a = 10
+    and b = [20, 21, 22]
+    and c = "30"
+
+    (* Update one field *)
+    val () =
+        let
+            val r1 = {r where a = a}
+            val r2 = {r where b = b}
+            val r3 = {r where c = c}
+            val allCorrect : bool = 
+                #a r1 = a    andalso #b r1 = #b r andalso #c r1 = #c r andalso
+                #a r2 = #a r andalso #b r2 = b    andalso #c r2 = #c r andalso
+                #a r3 = #a r andalso #b r3 = #b r andalso #c r3 = c
+        in
+            if allCorrect then () else raise Fail "Record update: update one field"
+        end
+
+    (* Update two fields *)
+    val () =
+        let
+            val r1 = {r where a = a, b = b}
+            val r2 = {r where a = a, c = c}
+            val r3 = {r where b = b, c = c}
+            val allCorrect : bool = 
+                #a r1 = a    andalso #b r1 = b    andalso #c r1 = #c r andalso
+                #a r2 = a    andalso #b r2 = #b r andalso #c r2 = c andalso
+                #a r3 = #a r andalso #b r3 = b    andalso #c r3 = c
+        in
+            if allCorrect then () else raise Fail "Record update: update two field"
+        end
+
+    (* Update all fields *)
+    val () =
+        let
+            val r1 = {r where a = a, b = b, c = c}
+            val allCorrect : bool = 
+                #a r1 = a    andalso #b r1 = b    andalso #c r1 = c
+        in
+            if allCorrect then () else raise Fail "Record update: update all field"
+        end
+
+    (* Record punning is supported *)
+    (* Update all fields *)
+    val () =
+        let
+            val r1 = {r where a}
+            val r2 = {r where b}
+            val r3 = {r where c}
+            val r4 = {r where a, b}
+            val r5 = {r where a, c}
+            val r6 = {r where b, c}
+            val r7 = {r where a, b, c}
+            val r8 = {r where a = a, b, c}
+            val r9 = {r where a, b = b, c}
+            val allCorrect : bool = 
+                #a r1 = a    andalso #b r1 = #b r andalso #c r1 = #c r andalso
+                #a r2 = #a r andalso #b r2 = b    andalso #c r2 = #c r andalso
+                #a r3 = #a r andalso #b r3 = #b r andalso #c r3 = c    andalso
+                #a r4 = a    andalso #b r4 = b    andalso #c r4 = #c r andalso
+                #a r5 = a    andalso #b r5 = #b r andalso #c r5 = c    andalso
+                #a r6 = #a r andalso #b r6 = b    andalso #c r6 = c    andalso
+                #a r7 = a    andalso #b r7 = b    andalso #c r7 = c    andalso
+                #a r8 = a    andalso #b r8 = b    andalso #c r8 = c    andalso
+                #a r9 = a    andalso #b r9 = b    andalso #c r9 = c
+        in
+            if allCorrect then () else raise Fail "Record update: update all field"
+        end
+in
+  ()
+end;
+
+(* Can be used on function parameters with inlined type annotation *)
+fun update (r : {a : int, b : int, c : int}) = {r where b = 1};
+
+(* Together, record update and record punning enable terse update of long records. *)
+structure S = struct
+    type longrec =
+        {aaa : int,
+         bbb : int * int,
+         ccc : int * int * int,
+         ddd : int list,
+         eee : int list list,
+         fff : int -> int,
+         ggg : int -> int -> int,
+         hhh : {x : int, y : int, z : int}} 
+
+    fun update_aaa (r : longrec) aaa : longrec = {r where aaa}
+    fun update_bbb (r : longrec) bbb : longrec = {r where bbb}
+    fun update_ccc (r : longrec) ccc : longrec = {r where ccc}
+    fun update_ddd (r : longrec) ddd : longrec = {r where ddd}
+    fun update_eee (r : longrec) eee : longrec = {r where eee}
+    fun update_fff (r : longrec) fff : longrec = {r where fff}
+    fun update_ggg (r : longrec) ggg : longrec = {r where ggg}
+    fun update_hhh (r : longrec) hhh : longrec = {r where hhh}
+
+end
+
+(* Type checking is performed through unification. *)
+structure S :> sig
+    type ('a, 'b) t; 
+    val getA: ('a, 'b) t -> 'a
+    val setA: ('a, 'b) t -> 'a -> ('a, 'b) t
+end = struct
+    type ('a, 'b) t = {a : 'a, b : 'b}; 
+    fun getA{a,...} = a
+    fun setA x y = {x where a = y}
+end;

--- a/mlsource/MLCompiler/COMPILER_BODY.ML
+++ b/mlsource/MLCompiler/COMPILER_BODY.ML
@@ -154,11 +154,12 @@ struct
                 let
                     (* create a "throw away" compiling environment for this topdec *)
                     val newFixEnv = UTILITIES.searchList ()
+                    and languageExtensions = DEBUG.getParameter DEBUG.languageExtensionsTag debugSwitches
                     val fixes : PARSEDEC.fixes =
                         {enterFix = #enter newFixEnv,
                          lookupFix = Misc.lookupDefault (#lookup newFixEnv) (#lookupFix globals)}
                     and params : PARSEDEC.params =
-                        {recordPunning = DEBUG.getParameter DEBUG.languageExtensionsTag debugSwitches}
+                        {recordPunning = languageExtensions, recordUpdate = languageExtensions}
 
                     val stopSyms = let open SYMSET in op ++ (abortParse, semicolon) end
                 in

--- a/mlsource/MLCompiler/PARSEDECSIG.sml
+++ b/mlsource/MLCompiler/PARSEDECSIG.sml
@@ -32,7 +32,8 @@ sig
         { enterFix:  string * fixStatus -> unit,
           lookupFix: string -> fixStatus option };
     type params =
-        { recordPunning: bool };
+        { recordPunning: bool,
+          recordUpdate: bool };
     type program;
 
     val parseDec: symset * lexan * fixes * params -> program;

--- a/mlsource/MLCompiler/PARSETREESIG.sml
+++ b/mlsource/MLCompiler/PARSETREESIG.sml
@@ -113,7 +113,7 @@ sig
     val mkDatatypeBinding : string * parseTypeVar list * valueConstr list * location * location -> datatypebind
     val mkValueConstr : string * typeParsetree option * location -> valueConstr
     val mkExBinding : string * parsetree * typeParsetree option * location * location -> exbind;
-    val mkLabelledTree : labelRecEntry list * bool * location -> parsetree;
+    val mkLabelledTree : (parsetree * location) option * labelRecEntry list * bool * location -> parsetree;
     val mkLabelRecEntry: string * location * parsetree * location -> labelRecEntry
     val mkSelector : string * location -> parsetree;
     val mkRaise : parsetree * location -> parsetree;

--- a/mlsource/MLCompiler/PARSE_DEC.ML
+++ b/mlsource/MLCompiler/PARSE_DEC.ML
@@ -157,7 +157,8 @@ struct
        lookupFix: string -> fixStatus option }
 
  type params =
-     { recordPunning: bool }
+     { recordPunning: bool,
+       recordUpdate: bool }
 
  local
 
@@ -173,7 +174,7 @@ struct
 
  in
 
- fun parseDec (fsys, lex, {enterFix, lookupFix}, {recordPunning}) : program =
+ fun parseDec (fsys, lex, {enterFix, lookupFix}, {recordPunning, recordUpdate}) : program =
  let
    (* These procedures to parse type declarations are used in both
       signature and expression parsing. *)
@@ -1021,47 +1022,111 @@ struct
                         val () = LEX.insymbol lex;
                         val posEnd = LEX.location lex
                     in
-                        case LEX.sy lex of
+                        (case LEX.sy lex of
                             RightCurly => (* Empty brackets denote unit *)
                             let val () = LEX.insymbol lex val locs = LEX.locSpan (startLocn, posEnd) in (unit locs, locs) end
 
-                        |   _ =>
-                            let (* lab1 = exp1, __ , labn = expn *)
+
+                        |   firstSymbol =>
+                            (* This could be either
+                               a record update (i.e., { r with lab1 = exp1, __ , labn = expn }) or
+                               a record expression (i.e., { lab1 = exp1, __  , labn = expn }). *)
+                            let
+
+                                val startsWithLabel =
+                                    (case firstSymbol of IntegerConst => true | Ident => true | _ => false)
+
+                                val (base : (parsetree * location) option, firstLabel) =
+                                    if startsWithLabel then (* May or may not be record extension *)
+                                        let
+                                            val label as (_, idLoc) = SKIPS.getLabel (fsys ++ equalsSign ++ whereSy, lex)
+                                        in
+                                            if LEX.sy lex = SYMBOLS.WhereSy then
+                                                (* Record extension *)
+                                                let
+                                                    val base = (mkIdent label, idLoc)
+                                                    val () = SKIPS.getsym (SYMBOLS.WhereSy, lex)
+                                                    val label = SKIPS.getLabel (fsys ++ equalsSign, lex)
+                                                in
+                                                    (SOME base, label)
+                                                end
+                                            else
+                                                (NONE, label)
+                                        end
+                                    else (* Record extension *)
+                                        let
+                                            val base = atomicExpression (fsys ++ whereSy)
+                                            val () = SKIPS.getsym (SYMBOLS.WhereSy, lex)
+                                            val label = SKIPS.getLabel (fsys ++ equalsSign, lex)
+                                        in
+                                            (SOME base, label)
+                                        end
+
                                 (* The same label name should not be used more than once. *)
                                 val dupCheck = UTILITIES.noDuplicates (reportDup lex)
+                                val () = #enter dupCheck firstLabel (* Check for dups. *)
 
-                                fun getEntry () =
+                                fun parseLabel () =
                                 let
-                                    val (ident, idLoc) = SKIPS.getLabel (fsys ++ equalsSign, lex);
-                                    val () = #enter dupCheck (ident, idLoc) (* Check for dups. *)
+                                    val label = SKIPS.getLabel (fsys ++ equalsSign, lex)
+                                    val () = #enter dupCheck label (* Check for dups. *)
+                                in
+                                    label
+                                end
+
+                                fun parseLabelExp (label as (ident, idLoc)) =
+                                let
                                     val (labExp, labLoc) =
-                                        case LEX.sy lex of
-                                            EqualsSign => (* Simple case -- lab = expression *)
-                                            (
-                                                SKIPS.getsym (SYMBOLS.EqualsSign, lex);
-                                                expression (fsys ++ commaRightCurlySy) env
-                                            )
-                                        |   _ =>
-                                            (
-                                                if recordPunning then (* sugared form - label is also variable symbol *)
-                                                    ()
-                                                else
-                                                    LEX.errorMessage (lex, LEX.location lex, " = expr expected after label. If you want to use record punning, please specify it in the parser's parameters.");
-                                                (* Sugared form not allowed for numeric labels. *)
-                                                assertIdentNotNumericLabel lex ident " = expr expected after numeric label";
-                                                (mkIdent (ident, idLoc), idLoc)
-                                            )
+                                        (case LEX.sy lex of
+                                            SYMBOLS.EqualsSign => (* Simple case -- label = expression *)
+                                            (LEX.insymbol lex; expression (fsys ++ commaRightCurlySy) env)
+                                        |   _ => (* sugared form - the expression is a variable with the same name as the label *)
+                                            let
+                                                val () = (* Check that the language extension is enabled. *)
+                                                    if recordPunning then
+                                                        ()
+                                                    else
+                                                        LEX.errorMessage (lex, LEX.location lex,
+                                                            " = expr expected after label. To use record punning, please specify it in the parser's parameters.");
+
+                                                val () = (* Sugared form not allowed for numeric labels. *)
+                                                    assertIdentNotNumericLabel lex ident " = expr expected after numeric label";
+                                            in
+                                                (mkIdent label, idLoc)
+                                            end)
                                     val locs = LEX.locSpan (idLoc, labLoc)
                                 in
-                                    (mkLabelRecEntry(ident, idLoc, labExp, locs), locs)
+                                    (mkLabelRecEntry (ident, idLoc, labExp, locs), locs)
                                 end
-                                val (labs, _, _) = SKIPS.getList (SYMBOLS.Comma, empty, lex) (fn () => let val (v, l) = getEntry() in (v, l, ()) end) ()
+
+                                (* Check that the language extension is enabled for record update. *)
+                                val () =
+                                    if Option.isSome base andalso not recordUpdate then
+                                        LEX.errorMessage (lex, LEX.location lex,
+                                            "To use record update, please specify it in the parser's parameters")
+                                    else
+                                        ()
+
+                                val (firstEntry, firstEntryLoc) = parseLabelExp firstLabel
+                                val otherEntries =
+                                    case LEX.sy lex of
+                                        SYMBOLS.RightCurly => []
+                                    |   _ =>
+                                    (
+                                        SKIPS.getsym (SYMBOLS.Comma, lex);
+                                        #1 (SKIPS.getList (SYMBOLS.Comma, empty, lex)
+                                            (fn () => let val (v, l) = parseLabelExp (parseLabel ()) in (v, l, ()) end) ())
+                                    )
+
+                                val labs = firstEntry :: otherEntries
+
+
                                 val locs = LEX.locSpan (startLocn, LEX.location lex) (* Include brackets. *)
-                                val labelled = mkLabelledTree (labs, true (* always frozen *), locs)
+                                val labelled = PARSETREE.mkLabelledTree (labs, true (* always frozen *), locs)
                                 val () = SKIPS.getsym (SYMBOLS.RightCurly, lex);
                             in
                                 (labelled, locs)
-                            end
+                            end)
                     end
 
                 (* local declaration *)

--- a/mlsource/MLCompiler/PARSE_DEC.ML
+++ b/mlsource/MLCompiler/PARSE_DEC.ML
@@ -851,7 +851,7 @@ struct
                                 val locs = LEX.locSpan (startLocn, LEX.location lex)
                                 val () = SKIPS.getsym (SYMBOLS.RightCurly, lex);
                             in
-                                (mkLabelledTree (result, frozen, locs), locs)
+                                (PARSETREE.mkLabelledTree (NONE, result, frozen, locs), locs)
                             end
                     end
 
@@ -1122,7 +1122,7 @@ struct
 
 
                                 val locs = LEX.locSpan (startLocn, LEX.location lex) (* Include brackets. *)
-                                val labelled = PARSETREE.mkLabelledTree (labs, true (* always frozen *), locs)
+                                val labelled = PARSETREE.mkLabelledTree (base, labs, true (* always frozen *), locs)
                                 val () = SKIPS.getsym (SYMBOLS.RightCurly, lex);
                             in
                                 (labelled, locs)

--- a/mlsource/MLCompiler/ParseTree/BASE_PARSE_TREE.sml
+++ b/mlsource/MLCompiler/ParseTree/BASE_PARSE_TREE.sml
@@ -189,7 +189,13 @@ struct
     |   Labelled            of
         (* Labelled record & the entry in the list. "frozen" is false if it's
            a pattern with "...". *)
-            { recList: labelRecEntry list, frozen: bool, expType: types ref, location: location }
+        {
+            base: (parsetree * location) option,
+            recList: labelRecEntry list,
+            frozen: bool,
+            expType: types ref,
+            location: location
+        }
 
     |   Selector            of
             { name: string, labType: types, typeof: types, location: location }

--- a/mlsource/MLCompiler/ParseTree/BaseParseTreeSig.sml
+++ b/mlsource/MLCompiler/ParseTree/BaseParseTreeSig.sml
@@ -192,7 +192,13 @@ sig
     |   Labelled            of
         (* Labelled record & the entry in the list. "frozen" is false if it's
            a pattern with "...". *)
-            { recList: labelRecEntry list, frozen: bool, expType: types ref, location: location }
+        {
+            base: (parsetree * location) option,
+            recList: labelRecEntry list,
+            frozen: bool,
+            expType: types ref,
+            location: location
+        }
 
     |   Selector            of
             { name: string, labType: types, typeof: types, location: location }

--- a/mlsource/MLCompiler/ParseTree/CODEGEN_PARSETREE.sml
+++ b/mlsource/MLCompiler/ParseTree/CODEGEN_PARSETREE.sml
@@ -586,9 +586,14 @@ struct
                     (selDecs, #load dec level :: tupleElems))) ([], []) (TYPETREE.recordFields expType)
 
             val allDecs =
-                List.foldr (fn (dec, decs) => #dec dec @ decs) [] baseDec @
-                List.foldr (fn (dec, decs) => #dec dec @ decs) [] selDecs @
-                List.foldr (fn ((_, dec), decs) => #dec dec @ decs) [] updateDecs
+                let
+                    (* Build the list from the back to the front to minimize traversals and temporary lists. *)
+                    val decs = List.foldr (fn ((_, dec), xs) => #dec dec @ xs) [] updateDecs
+                    val decs = List.foldr (fn (dec, xs) => #dec dec @ xs) decs selDecs
+                    val decs = List.foldr (fn (dec, xs) => #dec dec @ xs) decs baseDec
+                in
+                    decs
+                end
 
             val tuple = mkTuple tupleElems
         in

--- a/mlsource/MLCompiler/ParseTree/CODEGEN_PARSETREE.sml
+++ b/mlsource/MLCompiler/ParseTree/CODEGEN_PARSETREE.sml
@@ -532,38 +532,68 @@ struct
     |   codeGenerate(TupleTree{fields, ...}, context as { debugEnv, ...}) = (* Construct a vector of objects. *)
             (mkTuple(map (fn x => codegen (x, context)) fields), debugEnv)
 
-    |   codeGenerate(Labelled {recList = [{valOrPat, ...}], ...}, context) =
+    |   codeGenerate(Labelled {base = NONE, recList = [{valOrPat, ...}], ...}, context) =
             codeGenerate (valOrPat, context) (* optimise unary records *)
 
-    |   codeGenerate(Labelled {recList, expType=ref expType, ...}, context as { level, mkAddr, debugEnv, ...}) =
+    |   codeGenerate(Labelled {base, recList, expType=ref expType, ...}, context as {level, mkAddr, debugEnv, ...}) =
         let
             (* We must evaluate the expressions in the order they are
                written. This is not necessarily the order they appear
                in the record. *)
-            val recordSize = length recList; (* The size of the record. *)
-    
+
             (* First declare the values as local variables. *)
             (* We work down the list evaluating the expressions and putting
                the results away in temporaries. When we reach the end we
                construct the tuple by asking for each entry in turn. *) 
-            fun declist [] look = ([], mkTuple (List.tabulate (recordSize, look)))
-      
-            |   declist ({name, valOrPat, ...} :: t) look =
-                let
-                    val thisDec = 
-                        multipleUses (codegen (valOrPat, context), fn () => mkAddr 1, level);
-        
-                    val myPosition = entryNumber (name, expType);
-        
-                    fun lookFn i =
-                        if i = myPosition then #load thisDec (level) else look i
-                    val (otherDecs, tuple) = declist t lookFn
-                in
-                    (#dec thisDec @ otherDecs, tuple)
-                end
+
+            val baseDec =
+                (case base of
+                    NONE => []
+                |   SOME (baseExp, _) => [multipleUses (codegen (baseExp, context), fn () => mkAddr 1, level)]);
+            val updateDecs = List.map (fn {name, valOrPat, ...} =>
+                (name, multipleUses (codegen (valOrPat, context), fn () => mkAddr 1, level))) recList
+
+
+            val (selDecs, tupleElems) = List.foldr (fn ({name as labelName, typeOf as labelType}, (selDecs, tupleElems)) =>
+                (case List.find (fn (name, _) => labelName = name) updateDecs of
+                    NONE => (* The label is not in the update list; it must be in a nonempty base. *)
+                    let
+                        val baseExp =
+                            (case base of
+                                NONE => raise Misc.InternalError "codeGenerate Labelled - base expected"
+                            |   SOME (baseExp, _) => baseExp);
+
+                        val selector = Selector {
+                            name = labelName,
+                            labType = expType,
+                            typeof = mkFunctionType (expType, labelType),
+                            location = LEX.nullLocation
+                        }
+
+                        val selectorApplic = Applic {
+                          f = selector,
+                          arg = baseExp,
+                          location = LEX.nullLocation,
+                          isInfix = false,
+                          expType = ref (SimpleInstance labelType)
+                        }
+
+                        val dec = multipleUses (codegen (selectorApplic, context), fn () => mkAddr 1, level)
+                    in
+                        (dec :: selDecs, #load dec level :: tupleElems)
+                    end
+                |   SOME (_, dec) => (* The label is in the update list. *)
+                    (selDecs, #load dec level :: tupleElems))) ([], []) (TYPETREE.recordFields expType)
+
+            val allDecs =
+                List.foldr (fn (dec, decs) => #dec dec @ decs) [] baseDec @
+                List.foldr (fn (dec, decs) => #dec dec @ decs) [] selDecs @
+                List.foldr (fn ((_, dec), decs) => #dec dec @ decs) [] updateDecs
+
+            val tuple = mkTuple tupleElems
         in
             (* Create the record and package it up as a block. *)
-            (mkEnv (declist recList (fn _ => raise Misc.InternalError "missing in record")), debugEnv)
+            (mkEnv (allDecs, tuple), debugEnv)
         end
 
     |   codeGenerate(c as Selector {name, labType, location, ...}, { decName, lex, debugEnv, ...}) =

--- a/mlsource/MLCompiler/ParseTree/CODEGEN_PARSETREE.sml
+++ b/mlsource/MLCompiler/ParseTree/CODEGEN_PARSETREE.sml
@@ -535,8 +535,14 @@ struct
     |   codeGenerate(Labelled {base = NONE, recList = [{valOrPat, ...}], ...}, context) =
             codeGenerate (valOrPat, context) (* optimise unary records *)
 
-    |   codeGenerate(Labelled {base, recList, expType=ref expType, ...}, context as {level, mkAddr, debugEnv, ...}) =
+    |   codeGenerate(c as Labelled {base, recList, expType=ref expType, location, ...}, context as {lex, level, mkAddr, debugEnv, ...}) =
         let
+            (* Check that the type is frozen. *)
+            val () =
+                if recordNotFrozen expType
+                then errorNear (lex, true, c, location, "Can't find a fixed record type.")
+                else ();
+
             (* We must evaluate the expressions in the order they are
                written. This is not necessarily the order they appear
                in the record. *)

--- a/mlsource/MLCompiler/ParseTree/CODEGEN_PARSETREE.sml
+++ b/mlsource/MLCompiler/ParseTree/CODEGEN_PARSETREE.sml
@@ -564,11 +564,8 @@ struct
                     NONE => (* The label is not in the update list; it must be in a nonempty base. *)
                     let
                         val baseDec = List.hd baseDecs
-                        val selectorCode : codetree =
-                            if recordWidth expType = 1
-                            then #load baseDec level (* optimise unary tuples - no indirection! *)
-                            else mkInd (offset, #load baseDec level)
-
+                        (* No need to optimize unary tuples because record update requires at least one updated field. *)
+                        val selectorCode : codetree = mkInd (offset, #load baseDec level)
                         val dec = multipleUses (selectorCode, fn () => mkAddr 1, level)
                     in
                         (dec :: selDecs, #load dec level :: tupleElems)

--- a/mlsource/MLCompiler/ParseTree/CODEGEN_PARSETREE.sml
+++ b/mlsource/MLCompiler/ParseTree/CODEGEN_PARSETREE.sml
@@ -552,39 +552,29 @@ struct
                the results away in temporaries. When we reach the end we
                construct the tuple by asking for each entry in turn. *) 
 
-            val baseDec =
+            val baseDecs =
                 (case base of
                     NONE => []
                 |   SOME (baseExp, _) => [multipleUses (codegen (baseExp, context), fn () => mkAddr 1, level)]);
             val updateDecs = List.map (fn {name, valOrPat, ...} =>
                 (name, multipleUses (codegen (valOrPat, context), fn () => mkAddr 1, level))) recList
 
-
-            val (selDecs, tupleElems) = List.foldr (fn ({name as labelName, typeOf as labelType}, (selDecs, tupleElems)) =>
-                (case List.find (fn (name, _) => labelName = name) updateDecs of
+            val (selDecs, tupleElems) = List.foldr (fn (fieldName, (selDecs, tupleElems)) =>
+                (case List.find (fn (name, _) => fieldName = name) updateDecs of
                     NONE => (* The label is not in the update list; it must be in a nonempty base. *)
                     let
-                        val baseExp =
-                            (case base of
-                                NONE => raise Misc.InternalError "codeGenerate Labelled - base expected"
-                            |   SOME (baseExp, _) => baseExp);
+                        val baseDec = List.hd baseDecs
+                        val selectorCode : codetree =
+                            if recordWidth expType = 1
+                            then #load baseDec level (* optimise unary tuples - no indirection! *)
+                            else
+                            let
+                                val offset : int = entryNumber (fieldName, expType);
+                            in
+                                mkInd (offset, #load baseDec level)
+                            end
 
-                        val selector = Selector {
-                            name = labelName,
-                            labType = expType,
-                            typeof = mkFunctionType (expType, labelType),
-                            location = LEX.nullLocation
-                        }
-
-                        val selectorApplic = Applic {
-                          f = selector,
-                          arg = baseExp,
-                          location = LEX.nullLocation,
-                          isInfix = false,
-                          expType = ref (SimpleInstance labelType)
-                        }
-
-                        val dec = multipleUses (codegen (selectorApplic, context), fn () => mkAddr 1, level)
+                        val dec = multipleUses (selectorCode, fn () => mkAddr 1, level)
                     in
                         (dec :: selDecs, #load dec level :: tupleElems)
                     end
@@ -596,7 +586,7 @@ struct
                     (* Build the list from the back to the front to minimize traversals and temporary lists. *)
                     val decs = List.foldr (fn ((_, dec), xs) => #dec dec @ xs) [] updateDecs
                     val decs = List.foldr (fn (dec, xs) => #dec dec @ xs) decs selDecs
-                    val decs = List.foldr (fn (dec, xs) => #dec dec @ xs) decs baseDec
+                    val decs = List.foldr (fn (dec, xs) => #dec dec @ xs) decs baseDecs
                 in
                     decs
                 end

--- a/mlsource/MLCompiler/ParseTree/CODEGEN_PARSETREE.sml
+++ b/mlsource/MLCompiler/ParseTree/CODEGEN_PARSETREE.sml
@@ -559,7 +559,7 @@ struct
             val updateDecs = List.map (fn {name, valOrPat, ...} =>
                 (name, multipleUses (codegen (valOrPat, context), fn () => mkAddr 1, level))) recList
 
-            val (selDecs, tupleElems) = List.foldr (fn (fieldName, (selDecs, tupleElems)) =>
+            val (selDecs, tupleElems) = Utilities.foldri (fn (offset, fieldName, (selDecs, tupleElems)) =>
                 (case List.find (fn (name, _) => fieldName = name) updateDecs of
                     NONE => (* The label is not in the update list; it must be in a nonempty base. *)
                     let
@@ -567,12 +567,7 @@ struct
                         val selectorCode : codetree =
                             if recordWidth expType = 1
                             then #load baseDec level (* optimise unary tuples - no indirection! *)
-                            else
-                            let
-                                val offset : int = entryNumber (fieldName, expType);
-                            in
-                                mkInd (offset, #load baseDec level)
-                            end
+                            else mkInd (offset, #load baseDec level)
 
                         val dec = multipleUses (selectorCode, fn () => mkAddr 1, level)
                     in

--- a/mlsource/MLCompiler/ParseTree/PARSE_TREE.ML
+++ b/mlsource/MLCompiler/ParseTree/PARSE_TREE.ML
@@ -387,9 +387,10 @@ struct
           fullLoc     = fullLoc
         };
 
-    fun mkLabelledTree (recList, frozen, location) : parsetree = 
+    fun mkLabelledTree (base, recList, frozen, location) : parsetree =
      Labelled
        {
+         base = base,
          recList = recList,
          frozen  = frozen,
          expType  = ref BadType,

--- a/mlsource/MLCompiler/ParseTree/PRINT_PARSETREE.sml
+++ b/mlsource/MLCompiler/ParseTree/PRINT_PARSETREE.sml
@@ -623,7 +623,7 @@ struct
                 ]
             )
 
-      | Labelled {recList, frozen, ...} =>
+      | Labelled {base, recList, frozen, ...} =>
         let
             fun displayRecList (c, depth): pretty list =
             if depth <= 0 then [PrettyString "..."]
@@ -660,6 +660,9 @@ struct
         in
             PrettyBlock (2, false, [],
                 PrettyString "{" ::
+                (case base of
+                    NONE => []
+                |   SOME (exp, _) => [displayParsetree (exp, depth - 1), PrettyString " where "]) @
                 displayRecList (recList, depth - 1) @
                 (if frozen then [PrettyString "}"]
                 else [PrettyString (if null recList then "...}" else ", ...}")])

--- a/mlsource/MLCompiler/ParseTree/TYPECHECK_PARSETREE.sml
+++ b/mlsource/MLCompiler/ParseTree/TYPECHECK_PARSETREE.sml
@@ -867,7 +867,7 @@ struct
                 SimpleInstance tupleType
             end
           
-        |   assValues _ (v as Labelled {recList, frozen, expType, ...}) =
+        |   assValues _ (v as Labelled {base, recList, frozen, expType, location, ...}) =
             let
                 (* Process each item in the list. *)              
                 fun labEntryToLabType {name, valOrPat, expType, ...} =
@@ -877,10 +877,26 @@ struct
                     expType := ty;
                     {name = name, typeOf = ty }
                 end
-            
-              val expressionType =
-                mkLabelled 
-                    (sortLabels (map labEntryToLabType recList), frozen) (* should always be true *)
+
+                val expressionType =
+                    mkLabelled (sortLabels (map labEntryToLabType recList), not (Option.isSome base))
+                val () =
+                    (case base of
+                      NONE => ()
+                    | SOME (base, baseLoc) =>
+                        let val baseType = assValues v base in
+                            (case unifyTypes (baseType, SimpleInstance expressionType) of
+                             NONE => ()
+                            | SOME report =>
+                                (typeMismatch ("Type mismatch between the base record and its updated fields.",
+                                    valTypeMessage (lex, typeEnv) ("base:", base, baseType),
+                                    PrettyBlock(0, false, [], [
+                                        PrettyString "updated fields:",
+                                        PrettyBreak(1, 0),
+                                        display(SimpleInstance expressionType, 10000 (* All *), typeEnv)
+                                    ]),
+                                    unifyErrorReport (lex, typeEnv) report, lex, location, foundNear v)))
+                        end)
             in
                 expType := expressionType;
                 SimpleInstance expressionType

--- a/mlsource/MLCompiler/TYPETREESIG.sml
+++ b/mlsource/MLCompiler/TYPETREESIG.sml
@@ -63,7 +63,7 @@ sig
     val sortLabels:         {name: string, typeOf: types } list -> {name: string, typeOf: types } list;
     val entryNumber:        string * types -> int;
     val recordNotFrozen:    types -> bool;
-    val recordFields:       types -> {name: string, typeOf: types } list;
+    val recordFields:       types -> string list;
     val recordWidth:        types -> int
 
     (* Creates a map from the arguments to a type function.  The type function can then be processed

--- a/mlsource/MLCompiler/TYPETREESIG.sml
+++ b/mlsource/MLCompiler/TYPETREESIG.sml
@@ -63,6 +63,7 @@ sig
     val sortLabels:         {name: string, typeOf: types } list -> {name: string, typeOf: types } list;
     val entryNumber:        string * types -> int;
     val recordNotFrozen:    types -> bool;
+    val recordFields:       types -> {name: string, typeOf: types } list;
     val recordWidth:        types -> int
 
     (* Creates a map from the arguments to a type function.  The type function can then be processed

--- a/mlsource/MLCompiler/TYPE_TREE.ML
+++ b/mlsource/MLCompiler/TYPE_TREE.ML
@@ -2900,7 +2900,13 @@ struct
         |   _ => NONE
     end
 
+    fun recordFields (ty : types) =
+        (case canonicalise (ty, fn _ => NONE) of
+            (LabelledRecord fields, _) => fields
+        |   _ => raise Misc.InternalError "recordFields - not a record")
+
     local
+        (* TODO: Figure out whether this function could be expressed as a projection of `recordFields`. *)
         (* We have to use the full list; not all fields may be in recList. *)
         fun getFieldList(LabelledRecord rcrd) = map #name rcrd
         |   getFieldList(FlexibleRecordVar{fullList=ref full, ...}) = #names(followRefChainToEnd full)

--- a/mlsource/MLCompiler/TYPE_TREE.ML
+++ b/mlsource/MLCompiler/TYPE_TREE.ML
@@ -2900,19 +2900,6 @@ struct
         |   _ => NONE
     end
 
-    fun recordFields (ty : types) =
-        (case canonicalise (ty, fn _ => NONE) of
-            (LabelledRecord fields, _) => fields
-        |   (FlexibleRecordVar {recList = ref recList, ...}, _) =>
-                (* In a valid program the record would be frozen at this point and so the
-                   LabelledRecord case is the only one that can occur. However, the check for
-                   whether the record is frozen is done during the same pass as the call to this
-                   function. Since the code from this pass is never actually executed it doesn't
-                   matter too much what this case returns but it needs to return something
-                   sensible.*)
-                []
-        |   _ => raise Misc.InternalError "recordFields - not a record")
-
     local
         (* TODO: Figure out whether this function could be expressed as a projection of `recordFields`. *)
         (* We have to use the full list; not all fields may be in recList. *)
@@ -2939,7 +2926,8 @@ struct
 
         (* Size of a labelled record. *)
         and recordWidth rcrd = List.length(getFieldList rcrd)
-        
+
+        val recordFields = getFieldList
     end
 
     (* Get the codetree "types".  This is used during code-generation to see if

--- a/mlsource/MLCompiler/TYPE_TREE.ML
+++ b/mlsource/MLCompiler/TYPE_TREE.ML
@@ -2903,6 +2903,14 @@ struct
     fun recordFields (ty : types) =
         (case canonicalise (ty, fn _ => NONE) of
             (LabelledRecord fields, _) => fields
+        |   (FlexibleRecordVar {recList = ref recList, ...}, _) =>
+                (* In a valid program the record would be frozen at this point and so the
+                   LabelledRecord case is the only one that can occur. However, the check for
+                   whether the record is frozen is done during the same pass as the call to this
+                   function. Since the code from this pass is never actually executed it doesn't
+                   matter too much what this case returns but it needs to return something
+                   sensible.*)
+                []
         |   _ => raise Misc.InternalError "recordFields - not a record")
 
     local

--- a/mlsource/MLCompiler/Utilities.ML
+++ b/mlsource/MLCompiler/Utilities.ML
@@ -29,6 +29,8 @@ sig
                             enter:  string * 'a -> unit,
                             lookup: string -> 'a option};
     val splitString: string -> { first:string,second:string }
+
+    val foldri : (int * 'a * 'b -> 'b) -> 'b -> 'a list -> 'b
 end =
 struct
   (* A search list in which an identifier may only be entered once.
@@ -87,5 +89,12 @@ struct
             second = Substring.string second }
     end
 
+    fun foldri f =
+    let
+        fun foldri_aux _ b [] = b
+          | foldri_aux n b (x::xs) = f (n, x, foldri_aux (n + 1) b xs)
+    in
+        foldri_aux 0
+    end
 end;
    


### PR DESCRIPTION
Hi @dcjm,

here is a pull request that adds support for record update. It is disabled by default and can be enabled with the PolyML.Compiler.languageExtensions option. The syntax aims to mostly follow the one [proposed by SucessorML](https://smlfamily.github.io/successor-ml/OldSuccessorMLWiki/Functional_record_update.html).

Regards,
Martin
