### PR TITLE
Remove commented, old definition of the types context and pretty

### DIFF
--- a/mlsource/MLCompiler/PRETTY.sig
+++ b/mlsource/MLCompiler/PRETTY.sig
@@ -36,18 +36,6 @@ sig
     val projPrettyBreak: pretty -> int * int
     val projPrettyString: pretty -> string
 
-(*
-    datatype context =
-        ContextLocation of
-            { file: string, startLine: int, startPosition: int, endLine: int, endPosition: int }
-    |   ContextProperty of string * string (* User property. *)
-
-    datatype pretty =
-        PrettyBlock of int * bool * context list * pretty list
-    |   PrettyBreak of int * int
-    |   PrettyString of string
-*)
-
     (* A simple "pretty printer" that just accumulates strings. *)
     val uglyPrint: pretty -> string
 

--- a/mlsource/MLCompiler/Pretty.sml
+++ b/mlsource/MLCompiler/Pretty.sml
@@ -17,36 +17,6 @@
 
 structure Pretty:> PRETTY =
 struct
-
-(*    abstype context =
-        AbsContextLocation of
-            { file: string, startLine: int, startPosition: int, endLine: int, endPosition: int }
-    |   AbsContextProperty of string * string (* User property. *)
-
-    and pretty =
-        AbsPrettyBlock of int * bool * context list * pretty list
-    |   AbsPrettyBreak of int * int
-    |   AbsPrettyString of string
-    |   AbsPrettyStringAndWidth of string * int
-    |   AbsPrettyLineBreak
-    
-    with
-        val ContextLocation = AbsContextLocation
-        and ContextProperty = AbsContextProperty
-        
-        val PrettyBlock = AbsPrettyBlock
-        and PrettyBreak = AbsPrettyBreak
-        and PrettyString = AbsPrettyString
-        
-        fun isPrettyBlock(AbsPrettyBlock _) = true | isPrettyBlock _ = false
-        and isPrettyBreak(AbsPrettyBreak _) = true | isPrettyBreak _ = false
-        and isPrettyString(AbsPrettyString _) = true | isPrettyString _ = false
-
-        fun projPrettyBlock(AbsPrettyBlock b) = b | projPrettyBlock _ = raise Match
-        and projPrettyBreak(AbsPrettyBreak b) = b | projPrettyBreak _ = raise Match
-        and projPrettyString(AbsPrettyString b) = b | projPrettyString _ = raise Match
-    end;*)
-
     (* This is complicated because the data structures we use here will be exported into
        the code produced by the compiler.  We can't assume that the same representations
        will be used by this version of the compiler as are used by the compiler that is


### PR DESCRIPTION
Hi @dcjm,
I was reading the `PRETTY` signature and at first confused why the definition of the types `context` and `pretty` was commented. I then understood that the types are kept abstract with `type context` and `type pretty` and that functions (two for `context` and three for `pretty`) are provided to build values of theses types. As the functions looked the same as in the comment, I wondered why the comment was kept there. I searched the Git log and found the following:

Commit 320ea5cf26e18f8325609c476e1eaa0e2308d63b (2009-12-19) replaced the datatypes context and pretty by definitions based on the type `address`. The new definition was kept abstract in the signature PRETTY (then called PRETTYSIG). The commit messages states that this "removes the requirement that the representation of a datatype must be the same in the compiler that compiled the compiler as in the compiler itself." The original datatype declarations were kept in a comment.

Commit 10e0dd077e8ccf90af5cfb726ab1e3e6a6375e8a (2016-06-28) changed the interface of the `pretty` type by replacing `int` by `FixedInt.int`. This changed was not performed in the old, commented datatype declaration.

I propose to remove the comments. The code of the current definition is quite readable and, as of now, the reader must compare the commented definitions with the actual code to which point they are the same. Removing the comments also avoids the comment getting out of sync with the code.