### PR TITLE
Update the addresses of all objects that have been merged

### DIFF
--- a/libpolyml/gc_share_phase.cpp
+++ b/libpolyml/gc_share_phase.cpp
@@ -699,7 +699,6 @@ void SortVector::wordDataTask(GCTaskId*, void *a, void *)
                     // Update the addresses of objects that have been merged
                     h->Set(i, p->GetForwardingPtr());
                     s->carryOver++;
-                    break;
                 }
                 else if (state == CHAINED)
                 {


### PR DESCRIPTION
This leads to more objects being shared.
The break seems to have been introduced in b07ca831c1c4ba41c32edddeae38b635dff6f80a.

Fixes #289