### PR TITLE
Give the signal detection thread a 64k stack

### DIFF
--- a/libpolyml/sighandler.cpp
+++ b/libpolyml/sighandler.cpp
@@ -549,8 +549,8 @@ void SigHandler::Init(void)
 #ifdef PTHREAD_STACK_MIN
     // In glibc 2.34 and later, PTHREAD_STACK_MIN may expand to a function call
     size_t stacksize = PTHREAD_STACK_MIN; // Only small stack.
-    if (stacksize < 4096U) // But not too small: FreeBSD makes it 2k
-        stacksize = 4096U;
+    if (stacksize < 65536U) // But not too small: FreeBSD makes it 2k
+        stacksize = 65536U;
     pthread_attr_setstacksize(&attrs, stacksize);
 #endif
     threadRunning = pthread_create(&detectionThreadId, &attrs, SignalDetectionThread, 0) == 0;


### PR DESCRIPTION
The signal detection thread is created with the smallest stack the platform allows: PTHREAD_STACK_MIN, clamped to at least 4k. That is enough for SignalDetectionThread itself, but not necessarily for its exit path. On FreeBSD, pthread_exit() runs _Unwind_ForcedUnwind() on the dying thread's stack to execute cleanup handlers, and on powerpc64le the unwinder's register context and cursor structures cover 32 GPRs, 32 FPRs and 32 128-bit VSX registers, so the unwind frames alone exceed 4k and the thread faults on its stack guard page.

In practice this crashed every Poly/ML build on FreeBSD/powerpc64le with SIGSEGV just after "Writing object code": the bootstrap export completed, the RTS shut down, SigHandler::Stop() asked the thread to exit, and the forced unwind overflowed the 4k stack. amd64 gets away with 4k only because its unwind context is a few hundred bytes; glibc systems avoid the problem because PTHREAD_STACK_MIN is already much larger there (128k on powerpc64le).

Raise the minimum to 64k. There is only one such thread per process, so the cost is a single slightly larger mapping.