### PR TITLE
Fix ARM64 UBSan pointer overflow in GetConstSegmentForCode

### DIFF
--- a/libpolyml/arm64.cpp
+++ b/libpolyml/arm64.cpp
@@ -243,7 +243,7 @@ public:
         {
             // If the high-order byte is 0xff it's a (-ve) byte offset.
             POLYSIGNED offset = last_word->AsSigned();
-            cp = last_word + 1 + offset / sizeof(PolyWord);
+            cp = last_word + 1 + offset / (POLYSIGNED)sizeof(PolyWord);
             count = cp[-1].AsUnsigned();
         }
         else


### PR DESCRIPTION
Fixes #271.

Casts the divisor to `POLYSIGNED` so the negative offset isn't promoted to unsigned before the division. Without the cast, `offset / sizeof(PolyWord)` converts the negative offset to a large unsigned value and the resulting pointer addition overflows (UBSan: addition of unsigned offset overflowed).

Validated locally - both reproducers in #271 no longer trigger the UBSan violation.
