### PR TITLE
Process logging

### DIFF
--- a/libpolyml/diagnostics.cpp
+++ b/libpolyml/diagnostics.cpp
@@ -157,15 +157,15 @@ static FILE *logStream = NULL;
 static FILE *logStream = stdout;
 #endif
 
-void SetLogFile(const TCHAR *fileName)
+void SetLogFile(const TCHAR *fileName, bool append)
 {
 #if (defined(_WIN32) && defined(UNICODE))
-    FILE *stream = _wfopen(fileName, L"w");
+    FILE *stream = _wfopen(fileName, append ? L"a" : L"w");
     if (stream == NULL)
         fprintf(polyStdout, "Unable to open debug file %S\n", fileName);
     else logStream = stream;
 #else
-    FILE *stream = fopen(fileName, "w");
+    FILE *stream = fopen(fileName, append ? "a" : "w");
     if (stream == NULL)
         fprintf(polyStdout, "Unable to open debug file %s\n", fileName);
     else logStream = stream;

--- a/libpolyml/diagnostics.h
+++ b/libpolyml/diagnostics.h
@@ -32,6 +32,12 @@
 typedef char TCHAR;
 #endif
 
+#if (defined(_WIN32) && defined(UNICODE))
+#define TCHARFMT "S"
+#else
+#define TCHARFMT "s"
+#endif
+
 NORETURNFN(extern void Exit(const char *, ...));
 NORETURNFN(extern void Crash(const char *, ...));
 
@@ -57,5 +63,6 @@ extern unsigned    debugOptions; // debugging  flags
 #define DEBUG_RTSCALLS      0x0400      // Information about run-time calls. Not currently used.
 #define DEBUG_GC_ENHANCED   0x0800      // Intermediate level GC output
 #define DEBUG_SAVING        0x1000      // Saving state and exporting
+#define DEBUG_POLYPROC      0x2000      // Poly/ML process information
 
 #endif

--- a/libpolyml/diagnostics.h
+++ b/libpolyml/diagnostics.h
@@ -43,7 +43,7 @@ NORETURNFN(extern void Crash(const char *, ...));
 
 NORETURNFN(extern void ExitWithError(const char *, int err));
 
-extern void SetLogFile(const TCHAR *fileName);
+extern void SetLogFile(const TCHAR *fileName, bool append);
 extern void Log(const char *, ...);
 extern void LogSize(uintptr_t wordSize);
 

--- a/libpolyml/mpoly.cpp
+++ b/libpolyml/mpoly.cpp
@@ -60,6 +60,14 @@
 #include <sys/resource.h>
 #endif
 
+#ifdef HAVE_TIME_H
+#include <time.h>
+#endif
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
 #if (defined(_WIN32))
 #include <tchar.h>
 #else
@@ -94,6 +102,11 @@
 #include "winguiconsole.h"
 
 static const TCHAR *lpszServiceName = 0; // DDE service name
+#endif
+
+// Set from git describe when building from a repository.
+#ifndef GIT_VERSION
+#define GIT_VERSION "unknown"
 #endif
 
 FILE *polyStdout, *polyStderr; // Redirected in the Windows GUI
@@ -164,7 +177,8 @@ static struct __debugOpts {
     { _T("sharing"),            "Information from PolyML.shareCommonData",          DEBUG_SHARING},
     { _T("locks"),              "Information about contended locks",                DEBUG_CONTENTION},
     { _T("rts"),                "General run-time system calls",                    DEBUG_RTSCALLS},
-    { _T("saving"),             "Saving and loading state; exporting",              DEBUG_SAVING }
+    { _T("saving"),             "Saving and loading state; exporting",              DEBUG_SAVING },
+    { _T("polyproc"),           "Log Poly/ML process information",                  DEBUG_POLYPROC }
 };
 
 // Parse a parameter that is meant to be a size.  Returns the value as a number
@@ -369,6 +383,28 @@ int polymain(int argc, TCHAR **argv, exportDescription *exports)
             importFileName = argv[i];
         else
             userOptions.user_arg_strings[userOptions.user_arg_count++] = argv[i];
+    }
+
+    if (debugOptions & DEBUG_POLYPROC)
+    {
+        char buffer[sizeof("YYYY-MM-DDTHH:MM:SSZ")];
+        time_t now = time(NULL);
+        // Only one thread is running at this point so the non-reentrant
+        // gmtime is safe here.
+        struct tm *utc = gmtime(&now);
+        if (utc == NULL || strftime(buffer, sizeof(buffer), "%FT%TZ", utc) == 0)
+            strcpy(buffer, "unknown");
+
+#if (defined(_WIN32))
+        unsigned long pid = ::GetCurrentProcessId();
+#else
+        unsigned long pid = (unsigned long)getpid();
+#endif
+        Log("POLYPROC: Poly/ML " TextVersion " (" GIT_VERSION ") pid %lu started at %s:",
+            pid, buffer);
+        for (int i = 0; i < argc; i++)
+            Log(" %" TCHARFMT, argv[i]);
+        Log("\n");
     }
 
 #ifdef __HAIKU__

--- a/libpolyml/mpoly.cpp
+++ b/libpolyml/mpoly.cpp
@@ -128,6 +128,7 @@ enum {
     OPT_GCTHREADS,
     OPT_DEBUGOPTS,
     OPT_DEBUGFILE,
+    OPT_LOGAPPEND,
     OPT_DDESERVICE,
     OPT_CODEPAGE,
     OPT_REMOTESTATS,
@@ -148,6 +149,7 @@ static struct __argtab {
     { _T("--gcthreads"),    "Number of threads to use for garbage collection",      OPT_GCTHREADS },
     { _T("--debug"),        "Debug options: checkmem, gc, x",                       OPT_DEBUGOPTS },
     { _T("--logfile"),      "Logging file (default is to log to stdout)",           OPT_DEBUGFILE },
+    { _T("--logappend"),    "Append to the logging file rather than truncating it", OPT_LOGAPPEND },
     { _T("--enablegcsharing"), "Allow the garbage collector to run the sharing pass if needed",  OPT_GCSHARING },
 #if (defined(_WIN32))
 #ifdef UNICODE
@@ -256,6 +258,8 @@ int polymain(int argc, TCHAR **argv, exportDescription *exports)
         userOptions.programName = _T(""); // Set it to a valid empty string
     
     TCHAR *importFileName = 0;
+    const TCHAR *logFileName = 0;
+    bool logAppend = false;
     debugOptions       = 0;
 
     userOptions.user_arg_count   = 0;
@@ -275,7 +279,11 @@ int polymain(int argc, TCHAR **argv, exportDescription *exports)
                 {
                     const TCHAR *p = 0;
                     TCHAR *endp = 0;
-                    if (argTable[j].argKey != OPT_REMOTESTATS && argTable[j].argKey != OPT_GCSHARING)
+                    bool optionTakesValue =
+                        argTable[j].argKey != OPT_REMOTESTATS &&
+                        argTable[j].argKey != OPT_GCSHARING &&
+                        argTable[j].argKey != OPT_LOGAPPEND;
+                    if (optionTakesValue)
                     {
                         if (_tcslen(argv[i]) == argl)
                         { // If it has used all the argument pick the next
@@ -347,7 +355,11 @@ int polymain(int argc, TCHAR **argv, exportDescription *exports)
                         if (debugOptions & DEBUG_GC_ENHANCED) debugOptions |= DEBUG_GC;
                         break;
                     case OPT_DEBUGFILE:
-                        SetLogFile(p);
+                        logFileName = p;
+                        break;
+
+                    case OPT_LOGAPPEND:
+                        logAppend = true;
                         break;
 #if (defined(_WIN32))
                     case OPT_DDESERVICE:
@@ -384,6 +396,9 @@ int polymain(int argc, TCHAR **argv, exportDescription *exports)
         else
             userOptions.user_arg_strings[userOptions.user_arg_count++] = argv[i];
     }
+
+    if (logFileName != 0)
+        SetLogFile(logFileName, logAppend);
 
     if (debugOptions & DEBUG_POLYPROC)
     {


### PR DESCRIPTION
Hi @dcjm,
for debugging purposes, I would like to run Poly/ML with debug output to a file when building multiple Isabelle sessions. For each session, a new Poly/ML process is gets started. As of now, the file specified by `--logfile` gets opened in write mode, which means that the content of the file gets overridden every time.

To get the output for all sessions, I propose to add a new option `--logappend` to specify that the log file should be opened in append mode. The command-line interface is backward compatible: Without the option, the current behaviour of overriding the file is kept.

I also propose to add a new debug option `--debug polyproc` to output some information about the Poly/ML process at startup; the aim is to help identify which output corresponds to which Poly/ML process (e.g., in my case, this identifies the corresponding Isabelle session). The output looks like that:

```sh
$ printf "val x = 0;" | ./poly -q --debug polyproc
POLYPROC: Poly/ML 5.9.2 (eb3d10f3) pid 2348013 started at 2026-07-27T17:25:54Z: /home/martin/repos/polyml-martin/.libs/poly -q --debug polyproc
```