### PR TITLE
Better optimiser

### DIFF
--- a/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
+++ b/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
@@ -804,344 +804,333 @@ struct
     |   mapLambdaResult(bindings, lambda) =
             mkEnv([RecDecs(map(fn(addr, lam) => {addr=addr, use=[], lambda=lam}) bindings)], lambda)
 
-    fun optimise (context, use) (Lambda lambda) =
-            SOME(mapLambdaResult(optLambda(context, use, lambda, LCNormal)))
+    fun optimise (context, code, use) =
+    let
+        val { reprocess, makeAddr, codeTreePrinter, maxInlineSize = _ } = context
 
-    |   optimise (context as { reprocess, makeAddr, codeTreePrinter, ... }, use) (Newenv(envDecs, envExp)) =
-        let
-            fun mapExp mapUse code =
-                case optimise (context, mapUse) code of
-                    SOME result => result
-                |   NONE => mapCodetree (optimise(context, [UseGeneral])) code
+        fun doOptimise use (Lambda lambda) =
+                SOME(mapLambdaResult(optLambda(context, use, lambda, LCNormal)))
 
-            fun mapbinding(Declar{value, addr, use}) = Declar{value=mapExp use value, addr=addr, use=use}
-            |   mapbinding(RecDecs l) =
-                let
-                    fun mapRecDec({addr, lambda, use}, rest) =
-                        case optLambda(context, use, lambda, LCRecursive) of
-                            (bindings, Lambda lambdaRes) =>
-                                (* Turn any bindings into extra mutually-recursive functions. *)
-                                {addr=addr, use = use, lambda = lambdaRes } ::
-                                    map (fn (addr, res) => {addr=addr, use=use, lambda=res }) bindings @ rest
-                        |   _ => raise InternalError "mapbinding: not lambda"
-                in
-                    RecDecs(foldl mapRecDec [] l)
-                end
-            |   mapbinding(NullBinding exp) = NullBinding(mapExp [UseGeneral] exp)
-            |   mapbinding(Container{addr, use, size, setter}) =
-                let
-                    fun returnsContainer (Newenv(_, exp)) = returnsContainer exp
-                      | returnsContainer (Cond(_, t, e)) = returnsContainer t andalso returnsContainer e
-                      | returnsContainer (Handle {exp, handler, ...}) = returnsContainer exp andalso returnsContainer handler
-                      | returnsContainer (Raise _) =  true
-                      | returnsContainer (BeginLoop {loop, ...}) = returnsContainer loop
-                      | returnsContainer (Loop _) = true
-                      | returnsContainer (SetContainer _) = true
-                      | returnsContainer _ = false
-
-                    val redundant_fields   =
-                        if List.all(fn UseField _ => true | _ => false) use
-                        then
-                        let val newFilter = BoolVector.tabulate(size,
-                                  (fn i => List.exists (fn UseField(n,_) => n = i
-                                                         | _ => false) use))
-                        in
-                           if BoolVector.all (fn i => i) newFilter then NONE
-                           else SOME newFilter
-                        end
-                        else NONE
-                in
-                   case redundant_fields of
-                        NONE => Container{addr=addr, use=use, size=size, setter = mapExp [UseGeneral] setter}
-                   |    SOME newFilter =>
-                        if returnsContainer setter then
-                        let
-                            fun updateContainer leafFn (Newenv(envDecs, exp)) =
-                                      Newenv(envDecs, updateContainer leafFn exp)
-                              | updateContainer leafFn (Cond(i, t, e)) =
-                                      Cond(i,updateContainer leafFn t,updateContainer leafFn e)
-                              | updateContainer leafFn (Handle {exp, handler, exPacketAddr}) =
-                                      Handle{exp= updateContainer leafFn exp, handler = updateContainer leafFn handler, exPacketAddr=exPacketAddr}
-                              | updateContainer leafFn (BeginLoop {loop, arguments}) =
-                                      BeginLoop {loop = updateContainer leafFn loop,arguments = arguments}
-                              | updateContainer leafFn (SetContainer {tuple,filter,...}) = leafFn (tuple,filter)
-                              | updateContainer _ exp = exp
-                            val newSize = BoolVector.foldl (fn (true, n) => n+1 | (false, n) => n) 0 newFilter
-                        in
-                            if newSize = 1
-                            then
-                            let
-                                fun nthTrueIndex (n, vec) =
-                                let
-                                   val len = BoolVector.length vec
-                                   fun loop (i, count) =
-                                     if i = len
-                                     then raise InternalError "nthTrueIndex"
-                                     else if BoolVector.sub(vec, i)
-                                     then
-                                         if count = n then i
-                                         else loop (i+1, count+1)
-                                     else
-                                         loop (i+1, count)
-                                in
-                                   (loop (0, 0))
-                                end
-                                (* Find the offset *)
-                                val (offset,_) = valOf (BoolVector.findi (fn (_, b) => b) newFilter)
-                                val field = updateContainer (fn (tuple,filter) => mkInd(nthTrueIndex(offset,filter), tuple)) setter
-                                fun mkFields n = if n = offset then field else CodeZero
-                                val fields = List.tabulate(BoolVector.length newFilter, mkFields)
-                                val container = SetContainer{container= Extract(LoadLocal addr),
-                                                             tuple= Tuple{fields =fields ,isVariant=false},
-                                                             filter=BoolVector.tabulate(size,fn _ => true)}
-                            in
-                                reprocess := true;
-                                codeTreePrinter(PrettyString "Optimiser: Container; newSize = 1");
-                                Container{addr=addr, use=use, size=size, setter = container}
-                            end
-                            else
-                            let
-                                fun maskOut (vec, filt) =
-                                let
-                                    val filter_index = ref 0
-                                    fun f n = if BoolVector.sub(vec,n)
-                                              then (BoolVector.sub(filt,!filter_index)
-                                                    before filter_index := !filter_index + 1)
-                                              else false
-                                in
-                                    BoolVector.tabulate(BoolVector.length vec,f)
-                                end
-                                val newAddr = makeAddr()
-                                val newContainer = Extract(LoadLocal newAddr)
-                                val newSetter = updateContainer (fn (tuple,filter) => mkSetContainer(newContainer, tuple, maskOut(filter,newFilter))) setter
-                                val makeContainer = Container{addr=newAddr, use=[], size=newSize, setter = newSetter}
-                                val fields = List.rev (#2 (BoolVector.foldl
-                                        (fn (true,(a,l)) => (a+1,(mkIndContainer(a,newContainer))::l)
-                                          | (false,(a,l)) => (a,CodeZero::l)) (0,[]) newFilter))
-                                val container = SetContainer{container= Extract(LoadLocal addr),
-                                                             tuple= Tuple{fields =fields ,isVariant=false},
-                                                             filter=BoolVector.tabulate(size,fn _ => true)}
-                            in
-                                reprocess := true;
-                                codeTreePrinter(PrettyString "Optimiser: Container; newSize <>= 1");
-                                Container{addr=addr, use=use, size=size, setter=mkEnv([makeContainer], container)}
-                            end
-                        end
-                        else Container{addr=addr, use=use, size=size, setter = mapExp [UseGeneral] setter}
-                end
-        in
-            SOME(Newenv(map mapbinding envDecs, mapExp use envExp))
-        end
-
-        (* Immediate call to a function.  We may be able to expand this inline unless it
-           is recursive. *)
-    |   optimise (context, use) (Eval {function = Lambda lambda, argList, resultType}) =
-        let
-            val args = map (fn (c, t) => (optGeneral context c, t)) argList
-            val argTuples = map #1 args
-            val (bindings, newLambda) = optLambda(context, [UseApply(use, argTuples)], lambda, LCImmediateCall)
-            val call = Eval { function=newLambda, argList=args, resultType = resultType }
-        in
-            SOME(mapLambdaResult(bindings, call))
-        end
-
-    |   optimise (context as { reprocess, codeTreePrinter, ...}, use) (Eval {function = Cond(i, t, e), argList, resultType}) =
-        let
-            (* Transform "(if i then t else e) x" into "if i then t x else e x".  This
-               allows for other optimisations and inline expansion. *)
-            (* We duplicate the function arguments which could cause the size of the code
-               to blow-up if they involve complicated expressions. *)
-            fun pushFunction l =
+        |   doOptimise use (Newenv(envDecs, envExp)) =
             let
-                val code = Eval{function=l, argList=argList, resultType=resultType}
+                fun mapbinding(Declar{value, addr, use}) =
+                        Declar{value=optimise(context, value, use), addr=addr, use=use}
+                |   mapbinding(RecDecs l) =
+                    let
+                        fun mapRecDec({addr, lambda, use}, rest) =
+                            case optLambda(context, use, lambda, LCRecursive) of
+                                (bindings, Lambda lambdaRes) =>
+                                    (* Turn any bindings into extra mutually-recursive functions. *)
+                                    {addr=addr, use = use, lambda = lambdaRes } ::
+                                        map (fn (addr, res) => {addr=addr, use=use, lambda=res }) bindings @ rest
+                            |   _ => raise InternalError "mapbinding: not lambda"
+                    in
+                        RecDecs(foldl mapRecDec [] l)
+                    end
+                |   mapbinding(NullBinding exp) = NullBinding(optGeneral context exp)
+                |   mapbinding(Container{addr, use, size, setter}) =
+                    let
+                        fun returnsContainer (Newenv(_, exp)) = returnsContainer exp
+                          | returnsContainer (Cond(_, t, e)) = returnsContainer t andalso returnsContainer e
+                          | returnsContainer (Handle {exp, handler, ...}) = returnsContainer exp andalso returnsContainer handler
+                          | returnsContainer (Raise _) =  true
+                          | returnsContainer (BeginLoop {loop, ...}) = returnsContainer loop
+                          | returnsContainer (Loop _) = true
+                          | returnsContainer (SetContainer _) = true
+                          | returnsContainer _ = false
+
+                        val redundant_fields   =
+                            if List.all(fn UseField _ => true | _ => false) use
+                            then
+                            let val newFilter = BoolVector.tabulate(size,
+                                      (fn i => List.exists (fn UseField(n,_) => n = i
+                                                             | _ => false) use))
+                            in
+                               if BoolVector.all (fn i => i) newFilter then NONE
+                               else SOME newFilter
+                            end
+                            else NONE
+                    in
+                       case redundant_fields of
+                            NONE => Container{addr=addr, use=use, size=size, setter = optGeneral context setter}
+                       |    SOME newFilter =>
+                            if returnsContainer setter then
+                            let
+                                fun updateContainer leafFn (Newenv(envDecs, exp)) =
+                                          Newenv(envDecs, updateContainer leafFn exp)
+                                  | updateContainer leafFn (Cond(i, t, e)) =
+                                          Cond(i,updateContainer leafFn t,updateContainer leafFn e)
+                                  | updateContainer leafFn (Handle {exp, handler, exPacketAddr}) =
+                                          Handle{exp= updateContainer leafFn exp, handler = updateContainer leafFn handler, exPacketAddr=exPacketAddr}
+                                  | updateContainer leafFn (BeginLoop {loop, arguments}) =
+                                          BeginLoop {loop = updateContainer leafFn loop,arguments = arguments}
+                                  | updateContainer leafFn (SetContainer {tuple,filter,...}) = leafFn (tuple,filter)
+                                  | updateContainer _ exp = exp
+                                val newSize = BoolVector.foldl (fn (true, n) => n+1 | (false, n) => n) 0 newFilter
+                            in
+                                if newSize = 1
+                                then
+                                let
+                                    fun nthTrueIndex (n, vec) =
+                                    let
+                                       val len = BoolVector.length vec
+                                       fun loop (i, count) =
+                                         if i = len
+                                         then raise InternalError "nthTrueIndex"
+                                         else if BoolVector.sub(vec, i)
+                                         then
+                                             if count = n then i
+                                             else loop (i+1, count+1)
+                                         else
+                                             loop (i+1, count)
+                                    in
+                                       (loop (0, 0))
+                                    end
+                                    (* Find the offset *)
+                                    val (offset,_) = valOf (BoolVector.findi (fn (_, b) => b) newFilter)
+                                    val field = updateContainer (fn (tuple,filter) => mkInd(nthTrueIndex(offset,filter), tuple)) setter
+                                    fun mkFields n = if n = offset then field else CodeZero
+                                    val fields = List.tabulate(BoolVector.length newFilter, mkFields)
+                                    val container = SetContainer{container= Extract(LoadLocal addr),
+                                                                 tuple= Tuple{fields =fields ,isVariant=false},
+                                                                 filter=BoolVector.tabulate(size,fn _ => true)}
+                                in
+                                    reprocess := true;
+                                    codeTreePrinter(PrettyString "Optimiser: Container; newSize = 1");
+                                    Container{addr=addr, use=use, size=size, setter = container}
+                                end
+                                else
+                                let
+                                    fun maskOut (vec, filt) =
+                                    let
+                                        val filter_index = ref 0
+                                        fun f n = if BoolVector.sub(vec,n)
+                                                  then (BoolVector.sub(filt,!filter_index)
+                                                        before filter_index := !filter_index + 1)
+                                                  else false
+                                    in
+                                        BoolVector.tabulate(BoolVector.length vec,f)
+                                    end
+                                    val newAddr = makeAddr()
+                                    val newContainer = Extract(LoadLocal newAddr)
+                                    val newSetter = updateContainer (fn (tuple,filter) => mkSetContainer(newContainer, tuple, maskOut(filter,newFilter))) setter
+                                    val makeContainer = Container{addr=newAddr, use=[], size=newSize, setter = newSetter}
+                                    val fields = List.rev (#2 (BoolVector.foldl
+                                            (fn (true,(a,l)) => (a+1,(mkIndContainer(a,newContainer))::l)
+                                              | (false,(a,l)) => (a,CodeZero::l)) (0,[]) newFilter))
+                                    val container = SetContainer{container= Extract(LoadLocal addr),
+                                                                 tuple= Tuple{fields =fields ,isVariant=false},
+                                                                 filter=BoolVector.tabulate(size,fn _ => true)}
+                                in
+                                    reprocess := true;
+                                    codeTreePrinter(PrettyString "Optimiser: Container; newSize <>= 1");
+                                    Container{addr=addr, use=use, size=size, setter=mkEnv([makeContainer], container)}
+                                end
+                            end
+                            else Container{addr=addr, use=use, size=size, setter = optGeneral context setter}
+                    end
             in
-                case optimise (context, use) code of
-                    SOME result => result
-                |   NONE => mapCodetree (optimise(context, [UseGeneral])) code
+                SOME(Newenv(map mapbinding envDecs, optimise(context, envExp, use)))
             end
-        in
-            reprocess := true;
-            codeTreePrinter(PrettyString "Optimiser: Eval(if...) => if ... Eval else Eval");
-            SOME(Cond(i, pushFunction t, pushFunction e))
-        end
 
-    |   optimise (context, use) (Eval {function, argList, resultType}) =
-        (* If nothing else we need to ensure that "use" is correctly set on
-           the function and arguments and we don't simply pass the original. *)
-        let
-            val args = map (fn (c, t) => (optGeneral context c, t)) argList
-            val argTuples = map #1 args
-            val optFunction =
-                case optimise (context, [UseApply(use, argTuples)]) function of
-                    SOME result => result
-                |   NONE => mapCodetree (optimise(context, [UseGeneral])) function
-        in
-            SOME(
-                Eval{
-                    function= optFunction,
-                    argList=args, resultType = resultType
-                })
-        end
+            (* Immediate call to a function.  We may be able to expand this inline unless it
+               is recursive. *)
+        |   doOptimise use (Eval {function = Lambda lambda, argList, resultType}) =
+            let
+                val args = map (fn (c, t) => (optGeneral context c, t)) argList
+                val argTuples = map #1 args
+                val (bindings, newLambda) = optLambda(context, [UseApply(use, argTuples)], lambda, LCImmediateCall)
+                val call = Eval { function=newLambda, argList=args, resultType = resultType }
+            in
+                SOME(mapLambdaResult(bindings, call))
+            end
 
-    |   optimise (context, use) (Indirect{base, offset, indKind = IndTuple}) =
-        let
-            val optBase =
-                case optimise (context, [UseField(offset, use)]) base of
-                    SOME result => result
-                |   NONE => mapCodetree (optimise(context, [UseGeneral])) base
-        in
-            SOME(Indirect{base = optBase, offset = offset, indKind = IndTuple})
-        end
+        |   doOptimise use (Eval {function = Cond(i, t, e), argList, resultType}) =
+            let
+                (* Transform "(if i then t else e) x" into "if i then t x else e x".  This
+                   allows for other optimisations and inline expansion. *)
+                (* We duplicate the function arguments which could cause the size of the code
+                   to blow-up if they involve complicated expressions. *)
+                fun pushFunction l =
+                    optimise(context, Eval{function=l, argList=argList, resultType=resultType}, use)
+            in
+                reprocess := true;
+                codeTreePrinter(PrettyString "Optimiser: Eval(if...) => if ... Eval else Eval");
+                SOME(Cond(i, pushFunction t, pushFunction e))
+            end
 
-    |   optimise (context, use) (code as Cond(i, t, e)) =
-        (* If the result of the if-then-else is always taken apart as fields
-           then we are better off taking it apart further down and putting
-           the fields into a container on the stack. *)
-        if List.all(fn UseField _ => true | _ => false) use
-        then SOME(optFields(code, context, use))
-        (* However, if we're not optimising it we must make sure the context for each arm is [UseGeneral]
-           and not the usage for the conditional as a whole.  For example, if we're applying
-           the result of the conditional as a function we nevertheless mustn't optimise either
-           arm as though it was immediately applied to an argument. *)
-        else SOME(Cond(optGeneral context i, optGeneral context t, optGeneral context e))
+        |   doOptimise use (Eval {function, argList, resultType}) =
+            (* If nothing else we need to ensure that "use" is correctly set on
+               the function and arguments and we don't simply pass the original. *)
+            let
+                val args = map (fn (c, t) => (optGeneral context c, t)) argList
+                val argTuples = map #1 args
+            in
+                SOME(
+                    Eval{
+                        function= optimise(context, function, [UseApply(use, argTuples)]),
+                        argList=args, resultType = resultType
+                    })
+            end
 
-    |   optimise (context, use) (code as Handle{exp, handler, exPacketAddr}) =
-        (* Similarly for handlers: if the result is taken apart use a container. *)
-        if List.all(fn UseField _ => true | _ => false) use
-        then SOME(optFields(code, context, use))
-        else SOME(Handle{exp=optGeneral context exp, handler=optGeneral context handler, exPacketAddr=exPacketAddr})
+        |   doOptimise use (Indirect{base, offset, indKind = IndTuple}) =
+            SOME(Indirect{base = optimise(context, base, [UseField(offset, use)]),
+                          offset = offset, indKind = IndTuple})
 
-    |   optimise (context as { makeAddr, reprocess, codeTreePrinter, ...}, use) (code as BeginLoop{loop, arguments}) =
-        let
-            fun mapExp mapUse code =
-                case optimise (context, mapUse) code of
-                    SOME result => result
-                |   NONE => mapCodetree (optimise(context, [UseGeneral])) code
+        |   doOptimise use (code as Cond(i, t, e)) =
+            (* If the result of the if-then-else is always taken apart as fields
+               then we are better off taking it apart further down and putting
+               the fields into a container on the stack. *)
+            if List.all(fn UseField _ => true | _ => false) use
+            then SOME(optFields(code, context, use))
+            (* However, if we're not optimising it we must make sure the context for each arm is [UseGeneral]
+               and not the usage for the conditional as a whole.  For example, if we're applying
+               the result of the conditional as a function we nevertheless mustn't optimise either
+               arm as though it was immediately applied to an argument. *)
+            else SOME(Cond(optGeneral context i, optGeneral context t, optGeneral context e))
 
-            (* If an argument is a tuple and always taken apart within the loop we should
-               replace it with arguments for the fields.  This is the same as detupling
-               function arguments.
-               Note: the simplifier lifts loop variables out of the loop if they are
-               passed through unchanged so we don't need to consider that here. *)
-            fun checkArg(({use, addr, ...}, _) :: rest, argNo) =
-                if List.all (fn UseField _ => true | _ => false) use
-                then
-                let
-                    fun maxField(UseField(i, _), n) = Int.max(i, n) | maxField(_, n) = n
-                    val tupleSize = (List.foldl maxField 0 use) + 1
-                in
-                    SOME (tupleSize, addr, argNo)
-                end
-                else checkArg(rest, argNo+1)
+        |   doOptimise use (code as Handle{exp, handler, exPacketAddr}) =
+            (* Similarly for handlers: if the result is taken apart use a container. *)
+            if List.all(fn UseField _ => true | _ => false) use
+            then SOME(optFields(code, context, use))
+            else SOME(Handle{exp=optGeneral context exp, handler=optGeneral context handler, exPacketAddr=exPacketAddr})
 
-            |   checkArg ([], _) = NONE
+        |   doOptimise use (code as BeginLoop{loop, arguments}) =
+            let
+                (* If an argument is a tuple and always taken apart within the loop we should
+                   replace it with arguments for the fields.  This is the same as detupling
+                   function arguments.
+                   Note: the simplifier lifts loop variables out of the loop if they are
+                   passed through unchanged so we don't need to consider that here. *)
+                fun checkArg(({use, addr, ...}, _) :: rest, argNo) =
+                    if List.all (fn UseField _ => true | _ => false) use
+                    then
+                    let
+                        fun maxField(UseField(i, _), n) = Int.max(i, n) | maxField(_, n) = n
+                        val tupleSize = (List.foldl maxField 0 use) + 1
+                    in
+                        SOME (tupleSize, addr, argNo)
+                    end
+                    else checkArg(rest, argNo+1)
+
+                |   checkArg ([], _) = NONE
             
-            val tupleArgument = checkArg(arguments, 0)
-            (* Replace the original arguments by completely new ones.
-               Before the start of the body add bindings that provide definitions
-               of the old arguments.  For the one we're detupling that will involve
-               making a tuple.  Then find every Loop.  For the Loop we need to
-               replace the original arguments with new ones which will involve
-               passing the original values except for the detupled argument where
-               we need to detuple the value being passed in.
-               To preserve the order of evaluation and ensure that the expression that
-               returns the tuple is evaluated only once we need to bind all the existing
-               arguments to variables and then use the variables in the Loop expression.
-               This appears to add many new bindings and tuples but they will nearly all
-               be eliminated by the simplifier.
-               We don't need to check which of the tuple arguments are used; that
-               can be done later. *)
-        in
-            case tupleArgument of
-                SOME (tupleSize, addrForTuple, argumentNo) =>
-                let
-                    val finalArgLength = List.length arguments + tupleSize - 1
-                    (* Create new addresses for the fields. *)
-                    val tupleAddrs = List.tabulate(tupleSize, fn _ => makeAddr())
+                val tupleArgument = checkArg(arguments, 0)
+                (* Replace the original arguments by completely new ones.
+                   Before the start of the body add bindings that provide definitions
+                   of the old arguments.  For the one we're detupling that will involve
+                   making a tuple.  Then find every Loop.  For the Loop we need to
+                   replace the original arguments with new ones which will involve
+                   passing the original values except for the detupled argument where
+                   we need to detuple the value being passed in.
+                   To preserve the order of evaluation and ensure that the expression that
+                   returns the tuple is evaluated only once we need to bind all the existing
+                   arguments to variables and then use the variables in the Loop expression.
+                   This appears to add many new bindings and tuples but they will nearly all
+                   be eliminated by the simplifier.
+                   We don't need to check which of the tuple arguments are used; that
+                   can be done later. *)
+            in
+                case tupleArgument of
+                    SOME (tupleSize, addrForTuple, argumentNo) =>
+                    let
+                        val finalArgLength = List.length arguments + tupleSize - 1
+                        (* Create new addresses for the fields. *)
+                        val tupleAddrs = List.tabulate(tupleSize, fn _ => makeAddr())
 
-                    (* Deal with the initial values for the loop variables. *)
-                    fun replaceWithTuple [] = ([], [])
-                    |   replaceWithTuple((original as ({value, addr, ...}, _)) :: args) =
-                        let
-                            (* To preserve the evaluation order we have to bind each of the original
-                               arguments to a variable then pass a reference to this variable as the initial
-                               value of the loop variable.  The exception is that we replace the argument
-                               we're tupling with new variables and the value of each of these new variables
-                               is the tuple field. *)
-                            val newAddr = makeAddr()
-                            val dec = Declar{ addr = newAddr, use = [], value = value }
-                            val ext = Extract(LoadLocal newAddr) 
-                            val (restDecs, restArgs) = replaceWithTuple args
+                        (* Deal with the initial values for the loop variables. *)
+                        fun replaceWithTuple [] = ([], [])
+                        |   replaceWithTuple((original as ({value, addr, ...}, _)) :: args) =
+                            let
+                                (* To preserve the evaluation order we have to bind each of the original
+                                   arguments to a variable then pass a reference to this variable as the initial
+                                   value of the loop variable.  The exception is that we replace the argument
+                                   we're tupling with new variables and the value of each of these new variables
+                                   is the tuple field. *)
+                                val newAddr = makeAddr()
+                                val dec = Declar{ addr = newAddr, use = [], value = value }
+                                val ext = Extract(LoadLocal newAddr)
+                                val (restDecs, restArgs) = replaceWithTuple args
                             
-                            fun mkFields([], _) = restArgs
-                            |   mkFields(a :: rest, n) =
-                                    ({addr=a, value=mkInd(n, ext), use=[UseGeneral]}, GeneralType) ::
-                                        mkFields(rest, n+1)
-                        in
-                            if addr = addrForTuple
-                            then (dec :: restDecs, mkFields(tupleAddrs, 0))
-                            else (dec :: restDecs, original :: restArgs)
-                        end
-                    val (decs, newArgs) = replaceWithTuple arguments
+                                fun mkFields([], _) = restArgs
+                                |   mkFields(a :: rest, n) =
+                                        ({addr=a, value=mkInd(n, ext), use=[UseGeneral]}, GeneralType) ::
+                                            mkFields(rest, n+1)
+                            in
+                                if addr = addrForTuple
+                                then (dec :: restDecs, mkFields(tupleAddrs, 0))
+                                else (dec :: restDecs, original :: restArgs)
+                            end
+                        val (decs, newArgs) = replaceWithTuple arguments
 
-                    fun replaceLoop(Loop l) =
-                        let
-                            (* To preserve the evaluation order we need to bind the original arguments
-                               to variables.  Then the transformed arguments are the original arguments
-                               except for detupled argument which is replaced by its fields. *)
-                            val newAddresses = map (fn _ => makeAddr()) l
-                            val extractTuple = Extract(LoadLocal(List.nth(newAddresses, argumentNo)))
-                            val newDecs = ListPair.mapEq(fn((c, _), a) => Declar{addr=a, value=c, use=[]})(l, newAddresses)
-                            fun replaceArgs([], _) = []
-                            |   replaceArgs(arg :: rest, n) =
-                                if n = argumentNo
-                                then List.tabulate(tupleSize, fn i => (mkInd(i, extractTuple), GeneralType)) @ replaceArgs(rest, n+1)
-                                else arg :: replaceArgs(rest, n+1)
-                            val newLoopArgs = replaceArgs(l, 0)
-                            val () = if List.length newLoopArgs <> finalArgLength then raise InternalError "Bad length 1" else ()
-                            val loopBody = Loop newLoopArgs
-                        in
-                            SOME(mkEnv(newDecs, loopBody))
-                        end
-                    |   replaceLoop(l as Lambda _) = SOME l (* Not inside functions *)
-                    |   replaceLoop(l as BeginLoop _) = SOME l (* And not inside inner loops *)
-                    |   replaceLoop _ = NONE
+                        fun replaceLoop(Loop l) =
+                            let
+                                (* To preserve the evaluation order we need to bind the original arguments
+                                   to variables.  Then the transformed arguments are the original arguments
+                                   except for detupled argument which is replaced by its fields. *)
+                                val newAddresses = map (fn _ => makeAddr()) l
+                                val extractTuple = Extract(LoadLocal(List.nth(newAddresses, argumentNo)))
+                                val newDecs = ListPair.mapEq(fn((c, _), a) => Declar{addr=a, value=c, use=[]})(l, newAddresses)
+                                fun replaceArgs([], _) = []
+                                |   replaceArgs(arg :: rest, n) =
+                                    if n = argumentNo
+                                    then List.tabulate(tupleSize, fn i => (mkInd(i, extractTuple), GeneralType)) @ replaceArgs(rest, n+1)
+                                    else arg :: replaceArgs(rest, n+1)
+                                val newLoopArgs = replaceArgs(l, 0)
+                                val () = if List.length newLoopArgs <> finalArgLength then raise InternalError "Bad length 1" else ()
+                                val loopBody = Loop newLoopArgs
+                            in
+                                SOME(mkEnv(newDecs, loopBody))
+                            end
+                        |   replaceLoop(l as Lambda _) = SOME l (* Not inside functions *)
+                        |   replaceLoop(l as BeginLoop _) = SOME l (* And not inside inner loops *)
+                        |   replaceLoop _ = NONE
                     
-                    (* Inside the body we have to construct a tuple for the original argument.
-                       The simplifier will then replace every use of this with a reference to
-                       the new argument. *)
-                    val tupleForBody = mkTuple(map(fn a => Extract(LoadLocal a)) tupleAddrs)
-                    val newLoop =
-                        mkEnv([Declar{addr=addrForTuple, value=tupleForBody, use=[UseGeneral]}], mapCodetree replaceLoop loop)
+                        (* Inside the body we have to construct a tuple for the original argument.
+                           The simplifier will then replace every use of this with a reference to
+                           the new argument. *)
+                        val tupleForBody = mkTuple(map(fn a => Extract(LoadLocal a)) tupleAddrs)
+                        val newLoop =
+                            mkEnv([Declar{addr=addrForTuple, value=tupleForBody, use=[UseGeneral]}], mapCodetree replaceLoop loop)
 
-                    val () = reprocess := true
-                    val () = codeTreePrinter(PrettyString "Optimiser: replace loop")
-                    val () = if List.length newArgs <> finalArgLength then raise InternalError "Bad length 2" else ()
-                in
-                    SOME(mkEnv(decs, BeginLoop{loop=newLoop, arguments=newArgs}))
-                end
+                        val () = reprocess := true
+                        val () = codeTreePrinter(PrettyString "Optimiser: replace loop")
+                        val () = if List.length newArgs <> finalArgLength then raise InternalError "Bad length 2" else ()
+                    in
+                        SOME(mkEnv(decs, BeginLoop{loop=newLoop, arguments=newArgs}))
+                    end
 
-            |   NONE =>
-                (* If the result of the loop is taken apart we should push
-                   this down as well. *)
-                if List.all(fn UseField _ => true | _ => false) use
-                then SOME(optFields(code, context, use))
-                else
-                (* It's unsafe to detuple within a loop since it could potentially leave
-                   a Loop in a non tail position. Currently it's safe to generalize since
-                   the optFields check runs before this but still defensively swap into
-                   using [UseGeneral]. *)
-                SOME(BeginLoop{
-                        loop = mapExp [UseGeneral] loop,
-                        arguments =
-                            map (fn ({value, addr, use=argUse}, t) =>
-                                    ({value=mapExp argUse value, addr=addr, use=argUse}, t))
-                                arguments})
-        end
+                |   NONE =>
+                    (* If the result of the loop is taken apart we should push
+                       this down as well. *)
+                    if List.all(fn UseField _ => true | _ => false) use
+                    then SOME(optFields(code, context, use))
+                    else
+                    (* It's unsafe to detuple within a loop since it could potentially
+                       leave a Loop in a non tail position. Currently it's safe to
+                       generalize since the optFields check runs before this but still
+                       defensively swap into using [UseGeneral]. *)
+                    SOME(BeginLoop{
+                            loop = optimise(context, loop, [UseGeneral]),
+                            arguments =
+                                map (fn ({value, addr, use=argUse}, t) =>
+                                        ({value=optimise(context, value, argUse),
+                                          addr=addr, use=argUse}, t))
+                                    arguments})
+            end
 
-    |   optimise _ _ = NONE
-    
-    and optGeneral context exp = mapCodetree (optimise(context, [UseGeneral])) exp
+        |   doOptimise _ _ = NONE
+
+    in
+        (* The use describes how the result of this node is consumed.  If we don't
+           recognise the node, we can't know how it passes that on to its subtrees so
+           they have to be processed as general values. *)
+        case doOptimise use code of
+            SOME result => result
+        |   NONE => mapCodetree (doOptimise [UseGeneral]) code
+    end
+
+    and optGeneral context exp = optimise(context, exp, [UseGeneral])
 
     and optLambda(
             { maxInlineSize, reprocess, makeAddr, codeTreePrinter, ... },
@@ -1214,7 +1203,7 @@ struct
                     maxInlineSize = maxInlineSize,
                     codeTreePrinter = codeTreePrinter
                 }
-                val optBody = mapCodetree (optimise(optContext, [UseGeneral])) body
+                val optBody = optGeneral optContext body
                 val lambdaRes =
                     {
                         body = optBody,
@@ -1236,7 +1225,7 @@ struct
                     maxInlineSize = maxInlineSize,
                     codeTreePrinter = codeTreePrinter
                 }
-                val optBody = mapCodetree (optimise(optContext, [UseGeneral])) body
+                val optBody = optGeneral optContext body
 
                 (* See if this should be expanded inline.  If we are calling the lambda
                    immediately we try to expand it unless maxInlineSize is zero.  We
@@ -1660,10 +1649,7 @@ struct
                     then (preOptCode, optimisedOnce, simpAgain)
                     else
                     let
-                        val postOptCode =
-                            case optimise (optContext, [UseExport]) preOptCode of
-                                SOME result => result
-                            |   NONE => mapCodetree (optimise(optContext, [UseGeneral])) preOptCode
+                        val postOptCode = optimise(optContext, preOptCode, [UseExport])
                         (* Print the code after the optimiser. *)
                         val () = codeTreePrinter(Pretty.PrettyString "Output of optimiser")
                         val () = codeTreePrinter(BaseCodeTree.pretty postOptCode)

--- a/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
+++ b/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
@@ -956,7 +956,7 @@ struct
             in
                 reprocess := true;
                 codeTreePrinter(PrettyString "Optimiser: Eval(if...) => if ... Eval else Eval");
-                SOME(Cond(i, pushFunction t, pushFunction e))
+                SOME(Cond(optGeneral context i, pushFunction t, pushFunction e))
             end
 
         |   doOptimise use (Eval {function, argList, resultType}) =

--- a/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
+++ b/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
@@ -804,14 +804,17 @@ struct
     |   mapLambdaResult(bindings, lambda) =
             mkEnv([RecDecs(map(fn(addr, lam) => {addr=addr, use=[], lambda=lam}) bindings)], lambda)
 
-    (* How optimiseResult finishes off a result chain: loop_fn is applied to the
-       arguments of every Loop that belongs to the enclosing BeginLoop.  It is the
-       Loop constructor for an ordinary walk, which makes optimiseResult with
-       valueResult exactly optimise. *)
+    (* How optimiseResult finishes off the two kinds of end of a result chain.
+       loop_fn is applied to the arguments of every Loop that belongs to the enclosing
+       BeginLoop; leaf_fn is applied to the value at every leaf, before that value is
+       optimised, so a transformation can push something down to the leaves as the
+       walk reaches them rather than in a separate pass.  Both are the identity for
+       an ordinary walk, which makes optimiseResult with valueResult exactly
+       optimise. *)
     type resultContext =
-        { loop_fn: (codetree * argumentType) list -> codetree }
+        { loop_fn: (codetree * argumentType) list -> codetree, leaf_fn: codetree -> codetree }
 
-    val valueResult: resultContext = { loop_fn = Loop }
+    val valueResult: resultContext = { loop_fn = Loop, leaf_fn = fn code => code }
 
     fun optimise (context, code, use) =
     let
@@ -908,8 +911,9 @@ struct
     and optGeneral context exp = optimise(context, exp, [UseGeneral])
 
     (* Optimise a result position of the enclosing BeginLoop, applying the tail hook
-       to every Loop that belongs to it. *)
-    and optimiseResult (context, tailContext as { loop_fn }, code, use) =
+       to every Loop that belongs to it and the leaf hook to every value that is the
+       result. *)
+    and optimiseResult (context, tailContext as { loop_fn, leaf_fn }, code, use) =
     let
         val use = case use of [] => [UseGeneral] | _ => use
         fun allFields use = List.all(fn UseField _ => true | _ => false) use
@@ -937,14 +941,14 @@ struct
                 if allFields use
                 then optFields(code, context, tailContext, use)
                 else
-                Handle{exp = optimiseResult(context, valueResult, exp, [UseGeneral]),
+                Handle{exp = optimiseResult(context, { loop_fn = #loop_fn valueResult, leaf_fn = leaf_fn }, exp, [UseGeneral]),
                        handler = optimiseResult(context, tailContext, handler, [UseGeneral]),
                        exPacketAddr = exPacketAddr}
 
-        |   _ => optimise(context, code, use)
+        |   _ => optimise(context, leaf_fn code, use)
     end
 
-    and optimiseBeginLoop (context as { reprocess, makeAddr, codeTreePrinter, ...}, tailContext, loop, arguments) =
+    and optimiseBeginLoop (context as { reprocess, makeAddr, codeTreePrinter, ...}, tailContext as { loop_fn = _, leaf_fn }, loop, arguments) =
     let
         (* It's unsafe to detuple within a loop since it could potentially
            leave a Loop in a non tail position. Currently it's safe to
@@ -1046,7 +1050,7 @@ struct
                 val tupleForBody = mkTuple(map(fn a => Extract(LoadLocal a)) tupleAddrs)
                 val newLoop =
                     mkEnv([Declar{addr=addrForTuple, value=tupleForBody, use=[UseGeneral]}],
-                          optimiseResult(context, { loop_fn = detupleLoopArgs }, loop, use))
+                          optimiseResult(context, { loop_fn = detupleLoopArgs, leaf_fn = leaf_fn }, loop, use))
 
                 val () = reprocess := true
                 val () = codeTreePrinter(PrettyString "Optimiser: replace loop")
@@ -1056,10 +1060,11 @@ struct
             end
 
         |   NONE =>
-            (* Both the body and the initial values take the default tail
-               context: their Loops are ours, not the enclosing loop's. *)
+            (* The body's Loops are ours so it takes the default tail hook, but
+               it keeps the leaf hook - it sits inside whatever is being pushed
+               down. *)
             BeginLoop{
-                    loop = optimise(context, loop, use),
+                    loop = optimiseResult(context, { loop_fn = #loop_fn valueResult, leaf_fn = leaf_fn }, loop, use),
                     arguments =
                         map (fn ({value, addr, use=argUse}, t) =>
                                 ({value=optimise(context, value, argUse),
@@ -1452,7 +1457,10 @@ struct
             end
     end
 
-    and optFields (code, context as { reprocess, makeAddr, codeTreePrinter, ...}, tailContext, use) =
+    (* optFields is only called when every use is a UseField, and a live/non-identity
+       leaf hook only ever propagates along a chain carrying [UseGeneral] so there
+       isn't a need to compose. i.e. it will only be called when leaf_fn = fn loop => loop. *)
+    and optFields (code, context as { reprocess, makeAddr, codeTreePrinter, ...}, { loop_fn, leaf_fn = _ }, use) =
     let
         (* We have an if-then-else or a loop whose result is only ever
            taken apart.  We push this down. *)
@@ -1468,26 +1476,8 @@ struct
             val useList = BoolArray.foldri (fn (i, true, l) => i :: l | (_, _, l) => l) [] fieldUse
         end
 
-        fun pushContainer(Cond(ifpt, thenpt, elsept), leafFn) =
-                Cond(ifpt, pushContainer(thenpt, leafFn), pushContainer(elsept, leafFn))
-
-        |   pushContainer(Newenv(decs, exp), leafFn) =
-                Newenv(decs, pushContainer(exp, leafFn))
-
-        |   pushContainer(BeginLoop{loop, arguments}, leafFn) =
-                (* If we push it through a BeginLoop we MUST then push it through
-                   anything that could contain the Loop i.e. Cond, Newenv, Handle. *)
-                BeginLoop{loop = pushContainer(loop, leafFn), arguments=arguments}
-
-        |   pushContainer(l as Loop _, _) = l
-                (* Within a BeginLoop only the non-Loop leaves return
-                   values.  Loop entries go back to the BeginLoop so
-                   these are unchanged. *)
-
-        |   pushContainer(Handle{exp, handler, exPacketAddr}, leafFn) =
-                Handle{exp=pushContainer(exp, leafFn), handler=pushContainer(handler, leafFn), exPacketAddr=exPacketAddr}
-
-        |   pushContainer(tuple, leafFn) = leafFn tuple (* Anything else. *)
+        fun pushToLeaves leafFn =
+            optimiseResult(context, { loop_fn = loop_fn, leaf_fn = leafFn }, code, [UseGeneral])
 
         val () = reprocess := true
         val () = codeTreePrinter(PrettyString "Optimiser: pushed container")
@@ -1498,8 +1488,7 @@ struct
                 (* However the context still requires a tuple.  We need to
                    reconstruct one with unused fields set to zero.  They will
                    be filtered out later by the simplifier pass. *)
-                val field =
-                    optimiseResult(context, tailContext, pushContainer(code, fn t => mkInd(offset, t)), [UseGeneral])
+                val field = pushToLeaves (fn t => mkInd(offset, t))
                 fun mkFields n = if n = offset then field else CodeZero
             in
                 Tuple{ fields = List.tabulate(offset+1, mkFields), isVariant = false }
@@ -1511,11 +1500,11 @@ struct
                 val containerAddr = makeAddr()
                 val width = List.length useList
                 val loadContainer = Extract(LoadLocal containerAddr)
-
+                val filter = fieldsToFilter useList
                 fun setContainer tuple = (* At the leaf set the container. *)
-                    SetContainer{container = loadContainer, tuple = tuple, filter = fieldsToFilter useList }
+                    mkSetContainer(loadContainer, tuple, filter)
 
-                val setCode = optimiseResult(context, tailContext, pushContainer(code, setContainer), [UseGeneral])
+                val setCode = pushToLeaves setContainer
                 val makeContainer =
                     Container{addr=containerAddr, use=[], size=width, setter=setCode}
                 (* The context requires a tuple of the original width.  We need

--- a/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
+++ b/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
@@ -812,129 +812,7 @@ struct
                 SOME(mapLambdaResult(optLambda(context, use, lambda, LCNormal)))
 
         |   doOptimise use (Newenv(envDecs, envExp)) =
-            let
-                fun mapbinding(Declar{value, addr, use}) =
-                        Declar{value=optimise(context, value, use), addr=addr, use=use}
-                |   mapbinding(RecDecs l) =
-                    let
-                        fun mapRecDec({addr, lambda, use}, rest) =
-                            case optLambda(context, use, lambda, LCRecursive) of
-                                (bindings, Lambda lambdaRes) =>
-                                    (* Turn any bindings into extra mutually-recursive functions. *)
-                                    {addr=addr, use = use, lambda = lambdaRes } ::
-                                        map (fn (addr, res) => {addr=addr, use=use, lambda=res }) bindings @ rest
-                            |   _ => raise InternalError "mapbinding: not lambda"
-                    in
-                        RecDecs(foldl mapRecDec [] l)
-                    end
-                |   mapbinding(NullBinding exp) = NullBinding(optGeneral context exp)
-                |   mapbinding(Container{addr, use, size, setter}) =
-                    let
-                        fun returnsContainer (Newenv(_, exp)) = returnsContainer exp
-                          | returnsContainer (Cond(_, t, e)) = returnsContainer t andalso returnsContainer e
-                          | returnsContainer (Handle {exp, handler, ...}) = returnsContainer exp andalso returnsContainer handler
-                          | returnsContainer (Raise _) =  true
-                          | returnsContainer (BeginLoop {loop, ...}) = returnsContainer loop
-                          | returnsContainer (Loop _) = true
-                          | returnsContainer (SetContainer _) = true
-                          | returnsContainer _ = false
-
-                        val redundant_fields   =
-                            if List.all(fn UseField _ => true | _ => false) use
-                            then
-                            let val newFilter = BoolVector.tabulate(size,
-                                      (fn i => List.exists (fn UseField(n,_) => n = i
-                                                             | _ => false) use))
-                            in
-                               if BoolVector.all (fn i => i) newFilter then NONE
-                               else SOME newFilter
-                            end
-                            else NONE
-                    in
-                       case redundant_fields of
-                            NONE => Container{addr=addr, use=use, size=size, setter = optGeneral context setter}
-                       |    SOME newFilter =>
-                            if returnsContainer setter then
-                            let
-                                fun updateContainer leafFn (Newenv(envDecs, exp)) =
-                                          Newenv(envDecs, updateContainer leafFn exp)
-                                  | updateContainer leafFn (Cond(i, t, e)) =
-                                          Cond(i,updateContainer leafFn t,updateContainer leafFn e)
-                                  | updateContainer leafFn (Handle {exp, handler, exPacketAddr}) =
-                                          Handle{exp= updateContainer leafFn exp, handler = updateContainer leafFn handler, exPacketAddr=exPacketAddr}
-                                  | updateContainer leafFn (BeginLoop {loop, arguments}) =
-                                          BeginLoop {loop = updateContainer leafFn loop,arguments = arguments}
-                                  | updateContainer leafFn (SetContainer {tuple,filter,...}) = leafFn (tuple,filter)
-                                  | updateContainer _ exp = exp
-
-                                val newSize = BoolVector.foldl (fn (true, n) => n+1 | (false, n) => n) 0 newFilter
-                            in
-                                if newSize = 1
-                                then
-                                let
-                                    fun nthTrueIndex (n, vec) =
-                                    let
-                                       val len = BoolVector.length vec
-                                       fun loop (i, count) =
-                                         if i = len
-                                         then raise InternalError "nthTrueIndex"
-                                         else if BoolVector.sub(vec, i)
-                                         then
-                                             if count = n then i
-                                             else loop (i+1, count+1)
-                                         else
-                                             loop (i+1, count)
-                                    in
-                                       (loop (0, 0))
-                                    end
-                                    (* Find the offset *)
-                                    val (offset,_) = valOf (BoolVector.findi (fn (_, b) => b) newFilter)
-                                    val field =
-                                        optGeneral context (updateContainer (fn (tuple,filter) => mkInd(nthTrueIndex(offset,filter), tuple)) setter)
-                                    fun mkFields n = if n = offset then field else CodeZero
-                                    val fields = List.tabulate(BoolVector.length newFilter, mkFields)
-                                    val container = SetContainer{container= Extract(LoadLocal addr),
-                                                                 tuple= Tuple{fields =fields ,isVariant=false},
-                                                                 filter=BoolVector.tabulate(size,fn _ => true)}
-                                in
-                                    reprocess := true;
-                                    codeTreePrinter(PrettyString "Optimiser: Container; newSize = 1");
-                                    Container{addr=addr, use=use, size=size, setter = container}
-                                end
-                                else
-                                let
-                                    fun maskOut (vec, filt) =
-                                    let
-                                        val filter_index = ref 0
-                                        fun f n = if BoolVector.sub(vec,n)
-                                                  then (BoolVector.sub(filt,!filter_index)
-                                                        before filter_index := !filter_index + 1)
-                                                  else false
-                                    in
-                                        BoolVector.tabulate(BoolVector.length vec,f)
-                                    end
-                                    val newAddr = makeAddr()
-                                    val newContainer = Extract(LoadLocal newAddr)
-                                    val newSetter =
-                                        optGeneral context (updateContainer (fn (tuple,filter) => mkSetContainer(newContainer, tuple, maskOut(filter,newFilter))) setter)
-                                    val makeContainer = Container{addr=newAddr, use=[], size=newSize, setter = newSetter}
-                                    val fields = List.rev (#2 (BoolVector.foldl
-                                            (fn (true,(a,l)) => (a+1,(mkIndContainer(a,newContainer))::l)
-                                              | (false,(a,l)) => (a,CodeZero::l)) (0,[]) newFilter))
-                                    val container = SetContainer{container= Extract(LoadLocal addr),
-                                                                 tuple= Tuple{fields =fields ,isVariant=false},
-                                                                 filter=BoolVector.tabulate(size,fn _ => true)}
-                                in
-                                    reprocess := true;
-                                    codeTreePrinter(PrettyString "Optimiser: Container; newSize <>= 1");
-                                    Container{addr=addr, use=use, size=size, setter=mkEnv([makeContainer], container)}
-                                end
-                            end
-                            else Container{addr=addr, use=use, size=size, setter = optGeneral context setter}
-                    end
-            in
-                SOME(Newenv(map mapbinding envDecs, optimise(context, envExp, use)))
-            end
+                SOME(optimiseNewenv(context, envDecs, envExp, use))
 
             (* Immediate call to a function.  We may be able to expand this inline unless it
                is recursive. *)
@@ -1134,6 +1012,131 @@ struct
     end
 
     and optGeneral context exp = optimise(context, exp, [UseGeneral])
+
+    and optimiseNewenv (context as { reprocess, makeAddr, codeTreePrinter, ...}, envDecs, envExp, use) =
+    let
+        fun mapbinding(Declar{value, addr, use}) =
+                Declar{value=optimise(context, value, use), addr=addr, use=use}
+        |   mapbinding(RecDecs l) =
+            let
+                fun mapRecDec({addr, lambda, use}, rest) =
+                    case optLambda(context, use, lambda, LCRecursive) of
+                        (bindings, Lambda lambdaRes) =>
+                            (* Turn any bindings into extra mutually-recursive functions. *)
+                            {addr=addr, use = use, lambda = lambdaRes } ::
+                                map (fn (addr, res) => {addr=addr, use=use, lambda=res }) bindings @ rest
+                    |   _ => raise InternalError "mapbinding: not lambda"
+            in
+                RecDecs(foldl mapRecDec [] l)
+            end
+        |   mapbinding(NullBinding exp) = NullBinding(optGeneral context exp)
+        |   mapbinding(Container{addr, use, size, setter}) =
+            let
+                fun returnsContainer (Newenv(_, exp)) = returnsContainer exp
+                  | returnsContainer (Cond(_, t, e)) = returnsContainer t andalso returnsContainer e
+                  | returnsContainer (Handle {exp, handler, ...}) = returnsContainer exp andalso returnsContainer handler
+                  | returnsContainer (Raise _) =  true
+                  | returnsContainer (BeginLoop {loop, ...}) = returnsContainer loop
+                  | returnsContainer (Loop _) = true
+                  | returnsContainer (SetContainer _) = true
+                  | returnsContainer _ = false
+
+                val redundant_fields   =
+                    if List.all(fn UseField _ => true | _ => false) use
+                    then
+                    let val newFilter = BoolVector.tabulate(size,
+                              (fn i => List.exists (fn UseField(n,_) => n = i
+                                                     | _ => false) use))
+                    in
+                       if BoolVector.all (fn i => i) newFilter then NONE
+                       else SOME newFilter
+                    end
+                    else NONE
+            in
+               case redundant_fields of
+                    NONE => Container{addr=addr, use=use, size=size, setter = optGeneral context setter}
+               |    SOME newFilter =>
+                    if returnsContainer setter then
+                    let
+                        fun updateContainer leafFn (Newenv(envDecs, exp)) =
+                                  Newenv(envDecs, updateContainer leafFn exp)
+                          | updateContainer leafFn (Cond(i, t, e)) =
+                                  Cond(i,updateContainer leafFn t,updateContainer leafFn e)
+                          | updateContainer leafFn (Handle {exp, handler, exPacketAddr}) =
+                                  Handle{exp= updateContainer leafFn exp, handler = updateContainer leafFn handler, exPacketAddr=exPacketAddr}
+                          | updateContainer leafFn (BeginLoop {loop, arguments}) =
+                                  BeginLoop {loop = updateContainer leafFn loop,arguments = arguments}
+                          | updateContainer leafFn (SetContainer {tuple,filter,...}) = leafFn (tuple,filter)
+                          | updateContainer _ exp = exp
+
+                        val newSize = BoolVector.foldl (fn (true, n) => n+1 | (false, n) => n) 0 newFilter
+                    in
+                        if newSize = 1
+                        then
+                        let
+                            fun nthTrueIndex (n, vec) =
+                            let
+                               val len = BoolVector.length vec
+                               fun loop (i, count) =
+                                 if i = len
+                                 then raise InternalError "nthTrueIndex"
+                                 else if BoolVector.sub(vec, i)
+                                 then
+                                     if count = n then i
+                                     else loop (i+1, count+1)
+                                 else
+                                     loop (i+1, count)
+                            in
+                               (loop (0, 0))
+                            end
+                            (* Find the offset *)
+                            val (offset,_) = valOf (BoolVector.findi (fn (_, b) => b) newFilter)
+                            val field =
+                                optGeneral context (updateContainer (fn (tuple,filter) => mkInd(nthTrueIndex(offset,filter), tuple)) setter)
+                            fun mkFields n = if n = offset then field else CodeZero
+                            val fields = List.tabulate(BoolVector.length newFilter, mkFields)
+                            val container = SetContainer{container= Extract(LoadLocal addr),
+                                                         tuple= Tuple{fields =fields ,isVariant=false},
+                                                         filter=BoolVector.tabulate(size,fn _ => true)}
+                        in
+                            reprocess := true;
+                            codeTreePrinter(PrettyString "Optimiser: Container; newSize = 1");
+                            Container{addr=addr, use=use, size=size, setter = container}
+                        end
+                        else
+                        let
+                            fun maskOut (vec, filt) =
+                            let
+                                val filter_index = ref 0
+                                fun f n = if BoolVector.sub(vec,n)
+                                          then (BoolVector.sub(filt,!filter_index)
+                                                before filter_index := !filter_index + 1)
+                                          else false
+                            in
+                                BoolVector.tabulate(BoolVector.length vec,f)
+                            end
+                            val newAddr = makeAddr()
+                            val newContainer = Extract(LoadLocal newAddr)
+                            val newSetter =
+                                optGeneral context (updateContainer (fn (tuple,filter) => mkSetContainer(newContainer, tuple, maskOut(filter,newFilter))) setter)
+                            val makeContainer = Container{addr=newAddr, use=[], size=newSize, setter = newSetter}
+                            val fields = List.rev (#2 (BoolVector.foldl
+                                    (fn (true,(a,l)) => (a+1,(mkIndContainer(a,newContainer))::l)
+                                      | (false,(a,l)) => (a,CodeZero::l)) (0,[]) newFilter))
+                            val container = SetContainer{container= Extract(LoadLocal addr),
+                                                         tuple= Tuple{fields =fields ,isVariant=false},
+                                                         filter=BoolVector.tabulate(size,fn _ => true)}
+                        in
+                            reprocess := true;
+                            codeTreePrinter(PrettyString "Optimiser: Container; newSize <>= 1");
+                            Container{addr=addr, use=use, size=size, setter=mkEnv([makeContainer], container)}
+                        end
+                    end
+                    else Container{addr=addr, use=use, size=size, setter = optGeneral context setter}
+            end
+    in
+        Newenv(map mapbinding envDecs, optimise(context, envExp, use))
+    end
 
     and optLambda(
             { maxInlineSize, reprocess, makeAddr, codeTreePrinter, ... },

--- a/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
+++ b/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
@@ -804,6 +804,15 @@ struct
     |   mapLambdaResult(bindings, lambda) =
             mkEnv([RecDecs(map(fn(addr, lam) => {addr=addr, use=[], lambda=lam}) bindings)], lambda)
 
+    (* How optimiseResult finishes off a result chain: loop_fn is applied to the
+       arguments of every Loop that belongs to the enclosing BeginLoop.  It is the
+       Loop constructor for an ordinary walk, which makes optimiseResult with
+       valueResult exactly optimise. *)
+    type resultContext =
+        { loop_fn: (codetree * argumentType) list -> codetree }
+
+    val valueResult: resultContext = { loop_fn = Loop }
+
     fun optimise (context, code, use) =
     let
         val { reprocess, makeAddr, codeTreePrinter, maxInlineSize = _ } = context
@@ -812,7 +821,7 @@ struct
                 SOME(mapLambdaResult(optLambda(context, use, lambda, LCNormal)))
 
         |   doOptimise use (Newenv(envDecs, envExp)) =
-                SOME(optimiseNewenv(context, envDecs, envExp, use))
+                SOME(optimiseNewenv(context, valueResult, envDecs, envExp, use))
 
             (* Immediate call to a function.  We may be able to expand this inline unless it
                is recursive. *)
@@ -863,7 +872,7 @@ struct
                then we are better off taking it apart further down and putting
                the fields into a container on the stack. *)
             if List.all(fn UseField _ => true | _ => false) use
-            then SOME(optFields(code, context, use))
+            then SOME(optFields(code, context, valueResult, use))
             (* However, if we're not optimising it we must make sure the context for each arm is [UseGeneral]
                and not the usage for the conditional as a whole.  For example, if we're applying
                the result of the conditional as a function we nevertheless mustn't optimise either
@@ -873,7 +882,7 @@ struct
         |   doOptimise use (code as Handle{exp, handler, exPacketAddr}) =
             (* Similarly for handlers: if the result is taken apart use a container. *)
             if List.all(fn UseField _ => true | _ => false) use
-            then SOME(optFields(code, context, use))
+            then SOME(optFields(code, context, valueResult, use))
             else SOME(Handle{exp=optGeneral context exp, handler=optGeneral context handler, exPacketAddr=exPacketAddr})
 
         |   doOptimise use (code as BeginLoop{loop, arguments}) =
@@ -882,8 +891,8 @@ struct
                again with [UseGeneral], which is where the detupling below then
                happens, so we do not lose it. *)
             if List.all(fn UseField _ => true | _ => false) use
-            then SOME(optFields(code, context, use))
-            else SOME(optimiseBeginLoop(context, loop, arguments))
+            then SOME(optFields(code, context, valueResult, use))
+            else SOME(optimiseBeginLoop(context, valueResult, loop, arguments))
 
         |   doOptimise _ _ = NONE
 
@@ -898,7 +907,44 @@ struct
 
     and optGeneral context exp = optimise(context, exp, [UseGeneral])
 
-    and optimiseBeginLoop (context as { reprocess, makeAddr, codeTreePrinter, ...}, loop, arguments) =
+    (* Optimise a result position of the enclosing BeginLoop, applying the tail hook
+       to every Loop that belongs to it. *)
+    and optimiseResult (context, tailContext as { loop_fn }, code, use) =
+    let
+        val use = case use of [] => [UseGeneral] | _ => use
+        fun allFields use = List.all(fn UseField _ => true | _ => false) use
+    in
+        case code of
+            Loop args =>
+                loop_fn(map (fn (c, t) => (optGeneral context c, t)) args)
+
+        |   Newenv(envDecs, envExp) => optimiseNewenv(context, tailContext, envDecs, envExp, use)
+
+        |   BeginLoop{loop, arguments} =>
+                if allFields use
+                then optFields(code, context, tailContext, use)
+                else optimiseBeginLoop(context, tailContext, loop, arguments)
+
+        |   Cond(i, t, e) =>
+                if allFields use
+                then optFields(code, context, tailContext, use)
+                else
+                Cond(optGeneral context i,
+                     optimiseResult(context, tailContext, t, [UseGeneral]),
+                     optimiseResult(context, tailContext, e, [UseGeneral]))
+
+        |   Handle{exp, handler, exPacketAddr} =>
+                if allFields use
+                then optFields(code, context, tailContext, use)
+                else
+                Handle{exp = optimiseResult(context, valueResult, exp, [UseGeneral]),
+                       handler = optimiseResult(context, tailContext, handler, [UseGeneral]),
+                       exPacketAddr = exPacketAddr}
+
+        |   _ => optimise(context, code, use)
+    end
+
+    and optimiseBeginLoop (context as { reprocess, makeAddr, codeTreePrinter, ...}, tailContext, loop, arguments) =
     let
         (* It's unsafe to detuple within a loop since it could potentially
            leave a Loop in a non tail position. Currently it's safe to
@@ -957,7 +1003,7 @@ struct
                            we're tupling with new variables and the value of each of these new variables
                            is the tuple field. *)
                         val newAddr = makeAddr()
-                        val dec = Declar{ addr = newAddr, use = [], value = value }
+                        val dec = Declar{ addr = newAddr, use = [UseGeneral], value = value }
                         val ext = Extract(LoadLocal newAddr)
                         val (restDecs, restArgs) = replaceWithTuple args
 
@@ -972,35 +1018,35 @@ struct
                     end
                 val (decs, newArgs) = replaceWithTuple arguments
 
-                fun replaceLoop(Loop l) =
+                (* The tail context for the body: applied to every Loop that belongs
+                   to this BeginLoop. *)
+                fun detupleLoopArgs args =
                     let
                         (* To preserve the evaluation order we need to bind the original arguments
                            to variables.  Then the transformed arguments are the original arguments
                            except for detupled argument which is replaced by its fields. *)
-                        val newAddresses = map (fn _ => makeAddr()) l
+                        val newAddresses = map (fn _ => makeAddr()) args
                         val extractTuple = Extract(LoadLocal(List.nth(newAddresses, argumentNo)))
-                        val newDecs = ListPair.mapEq(fn((c, _), a) => Declar{addr=a, value=c, use=[]})(l, newAddresses)
+                        val newDecs = ListPair.mapEq(fn((c, _), a) => Declar{addr=a, value=c, use=[UseGeneral]})(args, newAddresses)
                         fun replaceArgs([], _) = []
                         |   replaceArgs(arg :: rest, n) =
                             if n = argumentNo
                             then List.tabulate(tupleSize, fn i => (mkInd(i, extractTuple), GeneralType)) @ replaceArgs(rest, n+1)
                             else arg :: replaceArgs(rest, n+1)
-                        val newLoopArgs = replaceArgs(l, 0)
+                        val newLoopArgs = replaceArgs(args, 0)
                         val () = if List.length newLoopArgs <> finalArgLength then raise InternalError "Bad length 1" else ()
                         val loopBody = Loop newLoopArgs
                     in
-                        SOME(mkEnv(newDecs, loopBody))
+                        mkEnv(newDecs, loopBody)
                     end
-                |   replaceLoop(l as Lambda _) = SOME l (* Not inside functions *)
-                |   replaceLoop(l as BeginLoop _) = SOME l (* And not inside inner loops *)
-                |   replaceLoop _ = NONE
 
                 (* Inside the body we have to construct a tuple for the original argument.
                    The simplifier will then replace every use of this with a reference to
                    the new argument. *)
                 val tupleForBody = mkTuple(map(fn a => Extract(LoadLocal a)) tupleAddrs)
                 val newLoop =
-                    mkEnv([Declar{addr=addrForTuple, value=tupleForBody, use=[UseGeneral]}], mapCodetree replaceLoop loop)
+                    mkEnv([Declar{addr=addrForTuple, value=tupleForBody, use=[UseGeneral]}],
+                          optimiseResult(context, { loop_fn = detupleLoopArgs }, loop, use))
 
                 val () = reprocess := true
                 val () = codeTreePrinter(PrettyString "Optimiser: replace loop")
@@ -1010,6 +1056,8 @@ struct
             end
 
         |   NONE =>
+            (* Both the body and the initial values take the default tail
+               context: their Loops are ours, not the enclosing loop's. *)
             BeginLoop{
                     loop = optimise(context, loop, use),
                     arguments =
@@ -1020,7 +1068,7 @@ struct
     end
 
 
-    and optimiseNewenv (context as { reprocess, makeAddr, codeTreePrinter, ...}, envDecs, envExp, use) =
+    and optimiseNewenv (context as { reprocess, makeAddr, codeTreePrinter, ...}, tailContext, envDecs, envExp, use) =
     let
         fun mapbinding(Declar{value, addr, use}) =
                 Declar{value=optimise(context, value, use), addr=addr, use=use}
@@ -1142,7 +1190,7 @@ struct
                     else Container{addr=addr, use=use, size=size, setter = optGeneral context setter}
             end
     in
-        Newenv(map mapbinding envDecs, optimise(context, envExp, use))
+        Newenv(map mapbinding envDecs, optimiseResult(context, tailContext, envExp, use))
     end
 
     and optLambda(
@@ -1404,7 +1452,7 @@ struct
             end
     end
 
-    and optFields (code, context as { reprocess, makeAddr, codeTreePrinter, ...}, use) =
+    and optFields (code, context as { reprocess, makeAddr, codeTreePrinter, ...}, tailContext, use) =
     let
         (* We have an if-then-else or a loop whose result is only ever
            taken apart.  We push this down. *)
@@ -1451,7 +1499,7 @@ struct
                    reconstruct one with unused fields set to zero.  They will
                    be filtered out later by the simplifier pass. *)
                 val field =
-                    optGeneral context (pushContainer(code, fn t => mkInd(offset, t)))
+                    optimiseResult(context, tailContext, pushContainer(code, fn t => mkInd(offset, t)), [UseGeneral])
                 fun mkFields n = if n = offset then field else CodeZero
             in
                 Tuple{ fields = List.tabulate(offset+1, mkFields), isVariant = false }
@@ -1467,7 +1515,7 @@ struct
                 fun setContainer tuple = (* At the leaf set the container. *)
                     SetContainer{container = loadContainer, tuple = tuple, filter = fieldsToFilter useList }
 
-                val setCode = optGeneral context (pushContainer(code, setContainer))
+                val setCode = optimiseResult(context, tailContext, pushContainer(code, setContainer), [UseGeneral])
                 val makeContainer =
                     Container{addr=containerAddr, use=[], size=width, setter=setCode}
                 (* The context requires a tuple of the original width.  We need

--- a/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
+++ b/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
@@ -866,6 +866,7 @@ struct
                                           BeginLoop {loop = updateContainer leafFn loop,arguments = arguments}
                                   | updateContainer leafFn (SetContainer {tuple,filter,...}) = leafFn (tuple,filter)
                                   | updateContainer _ exp = exp
+
                                 val newSize = BoolVector.foldl (fn (true, n) => n+1 | (false, n) => n) 0 newFilter
                             in
                                 if newSize = 1
@@ -888,7 +889,8 @@ struct
                                     end
                                     (* Find the offset *)
                                     val (offset,_) = valOf (BoolVector.findi (fn (_, b) => b) newFilter)
-                                    val field = updateContainer (fn (tuple,filter) => mkInd(nthTrueIndex(offset,filter), tuple)) setter
+                                    val field =
+                                        optGeneral context (updateContainer (fn (tuple,filter) => mkInd(nthTrueIndex(offset,filter), tuple)) setter)
                                     fun mkFields n = if n = offset then field else CodeZero
                                     val fields = List.tabulate(BoolVector.length newFilter, mkFields)
                                     val container = SetContainer{container= Extract(LoadLocal addr),
@@ -913,7 +915,8 @@ struct
                                     end
                                     val newAddr = makeAddr()
                                     val newContainer = Extract(LoadLocal newAddr)
-                                    val newSetter = updateContainer (fn (tuple,filter) => mkSetContainer(newContainer, tuple, maskOut(filter,newFilter))) setter
+                                    val newSetter =
+                                        optGeneral context (updateContainer (fn (tuple,filter) => mkSetContainer(newContainer, tuple, maskOut(filter,newFilter))) setter)
                                     val makeContainer = Container{addr=newAddr, use=[], size=newSize, setter = newSetter}
                                     val fields = List.rev (#2 (BoolVector.foldl
                                             (fn (true,(a,l)) => (a+1,(mkIndContainer(a,newContainer))::l)

--- a/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
+++ b/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
@@ -883,126 +883,7 @@ struct
                happens, so we do not lose it. *)
             if List.all(fn UseField _ => true | _ => false) use
             then SOME(optFields(code, context, use))
-            else
-            let
-                (* It's unsafe to detuple within a loop since it could potentially
-                   leave a Loop in a non tail position. Currently it's safe to
-                   generalize since the optFields check runs before this but still
-                   defensively swap into using [UseGeneral]. *)
-                val use = [UseGeneral]
-
-                (* If an argument is a tuple and always taken apart within the loop we should
-                   replace it with arguments for the fields.  This is the same as detupling
-                   function arguments.
-                   Note: the simplifier lifts loop variables out of the loop if they are
-                   passed through unchanged so we don't need to consider that here. *)
-                fun checkArg(({use, addr, ...}, _) :: rest, argNo) =
-                    if List.all (fn UseField _ => true | _ => false) use
-                    then
-                    let
-                        fun maxField(UseField(i, _), n) = Int.max(i, n) | maxField(_, n) = n
-                        val tupleSize = (List.foldl maxField 0 use) + 1
-                    in
-                        SOME (tupleSize, addr, argNo)
-                    end
-                    else checkArg(rest, argNo+1)
-
-                |   checkArg ([], _) = NONE
-            
-                val tupleArgument = checkArg(arguments, 0)
-                (* Replace the original arguments by completely new ones.
-                   Before the start of the body add bindings that provide definitions
-                   of the old arguments.  For the one we're detupling that will involve
-                   making a tuple.  Then find every Loop.  For the Loop we need to
-                   replace the original arguments with new ones which will involve
-                   passing the original values except for the detupled argument where
-                   we need to detuple the value being passed in.
-                   To preserve the order of evaluation and ensure that the expression that
-                   returns the tuple is evaluated only once we need to bind all the existing
-                   arguments to variables and then use the variables in the Loop expression.
-                   This appears to add many new bindings and tuples but they will nearly all
-                   be eliminated by the simplifier.
-                   We don't need to check which of the tuple arguments are used; that
-                   can be done later. *)
-            in
-                case tupleArgument of
-                    SOME (tupleSize, addrForTuple, argumentNo) =>
-                    let
-                        val finalArgLength = List.length arguments + tupleSize - 1
-                        (* Create new addresses for the fields. *)
-                        val tupleAddrs = List.tabulate(tupleSize, fn _ => makeAddr())
-
-                        (* Deal with the initial values for the loop variables. *)
-                        fun replaceWithTuple [] = ([], [])
-                        |   replaceWithTuple((original as ({value, addr, ...}, _)) :: args) =
-                            let
-                                (* To preserve the evaluation order we have to bind each of the original
-                                   arguments to a variable then pass a reference to this variable as the initial
-                                   value of the loop variable.  The exception is that we replace the argument
-                                   we're tupling with new variables and the value of each of these new variables
-                                   is the tuple field. *)
-                                val newAddr = makeAddr()
-                                val dec = Declar{ addr = newAddr, use = [], value = value }
-                                val ext = Extract(LoadLocal newAddr)
-                                val (restDecs, restArgs) = replaceWithTuple args
-                            
-                                fun mkFields([], _) = restArgs
-                                |   mkFields(a :: rest, n) =
-                                        ({addr=a, value=mkInd(n, ext), use=[UseGeneral]}, GeneralType) ::
-                                            mkFields(rest, n+1)
-                            in
-                                if addr = addrForTuple
-                                then (dec :: restDecs, mkFields(tupleAddrs, 0))
-                                else (dec :: restDecs, original :: restArgs)
-                            end
-                        val (decs, newArgs) = replaceWithTuple arguments
-
-                        fun replaceLoop(Loop l) =
-                            let
-                                (* To preserve the evaluation order we need to bind the original arguments
-                                   to variables.  Then the transformed arguments are the original arguments
-                                   except for detupled argument which is replaced by its fields. *)
-                                val newAddresses = map (fn _ => makeAddr()) l
-                                val extractTuple = Extract(LoadLocal(List.nth(newAddresses, argumentNo)))
-                                val newDecs = ListPair.mapEq(fn((c, _), a) => Declar{addr=a, value=c, use=[]})(l, newAddresses)
-                                fun replaceArgs([], _) = []
-                                |   replaceArgs(arg :: rest, n) =
-                                    if n = argumentNo
-                                    then List.tabulate(tupleSize, fn i => (mkInd(i, extractTuple), GeneralType)) @ replaceArgs(rest, n+1)
-                                    else arg :: replaceArgs(rest, n+1)
-                                val newLoopArgs = replaceArgs(l, 0)
-                                val () = if List.length newLoopArgs <> finalArgLength then raise InternalError "Bad length 1" else ()
-                                val loopBody = Loop newLoopArgs
-                            in
-                                SOME(mkEnv(newDecs, loopBody))
-                            end
-                        |   replaceLoop(l as Lambda _) = SOME l (* Not inside functions *)
-                        |   replaceLoop(l as BeginLoop _) = SOME l (* And not inside inner loops *)
-                        |   replaceLoop _ = NONE
-                    
-                        (* Inside the body we have to construct a tuple for the original argument.
-                           The simplifier will then replace every use of this with a reference to
-                           the new argument. *)
-                        val tupleForBody = mkTuple(map(fn a => Extract(LoadLocal a)) tupleAddrs)
-                        val newLoop =
-                            mkEnv([Declar{addr=addrForTuple, value=tupleForBody, use=[UseGeneral]}], mapCodetree replaceLoop loop)
-
-                        val () = reprocess := true
-                        val () = codeTreePrinter(PrettyString "Optimiser: replace loop")
-                        val () = if List.length newArgs <> finalArgLength then raise InternalError "Bad length 2" else ()
-                    in
-                        SOME(mkEnv(decs, BeginLoop{loop=newLoop, arguments=newArgs}))
-                    end
-
-                |   NONE =>
-                    SOME(BeginLoop{
-                            loop = optimise(context, loop, use),
-                            arguments =
-                                map (fn ({value, addr, use=argUse}, t) =>
-                                        ({value=optimise(context, value, argUse),
-                                          addr=addr, use=argUse}, t))
-                                    arguments})
-            end
+            else SOME(optimiseBeginLoop(context, loop, arguments))
 
         |   doOptimise _ _ = NONE
 
@@ -1016,6 +897,128 @@ struct
     end
 
     and optGeneral context exp = optimise(context, exp, [UseGeneral])
+
+    and optimiseBeginLoop (context as { reprocess, makeAddr, codeTreePrinter, ...}, loop, arguments) =
+    let
+        (* It's unsafe to detuple within a loop since it could potentially
+           leave a Loop in a non tail position. Currently it's safe to
+           generalize since the optFields check runs before this but still
+           defensively swap into using [UseGeneral]. *)
+        val use = [UseGeneral]
+
+        (* If an argument is a tuple and always taken apart within the loop we should
+           replace it with arguments for the fields.  This is the same as detupling
+           function arguments.
+           Note: the simplifier lifts loop variables out of the loop if they are
+           passed through unchanged so we don't need to consider that here. *)
+        fun checkArg(({use, addr, ...}, _) :: rest, argNo) =
+            if List.all (fn UseField _ => true | _ => false) use
+            then
+            let
+                fun maxField(UseField(i, _), n) = Int.max(i, n) | maxField(_, n) = n
+                val tupleSize = (List.foldl maxField 0 use) + 1
+            in
+                SOME (tupleSize, addr, argNo)
+            end
+            else checkArg(rest, argNo+1)
+
+        |   checkArg ([], _) = NONE
+
+        val tupleArgument = checkArg(arguments, 0)
+        (* Replace the original arguments by completely new ones.
+           Before the start of the body add bindings that provide definitions
+           of the old arguments.  For the one we're detupling that will involve
+           making a tuple.  Then find every Loop.  For the Loop we need to
+           replace the original arguments with new ones which will involve
+           passing the original values except for the detupled argument where
+           we need to detuple the value being passed in.
+           To preserve the order of evaluation and ensure that the expression that
+           returns the tuple is evaluated only once we need to bind all the existing
+           arguments to variables and then use the variables in the Loop expression.
+           This appears to add many new bindings and tuples but they will nearly all
+           be eliminated by the simplifier.
+           We don't need to check which of the tuple arguments are used; that
+           can be done later. *)
+    in
+        case tupleArgument of
+            SOME (tupleSize, addrForTuple, argumentNo) =>
+            let
+                val finalArgLength = List.length arguments + tupleSize - 1
+                (* Create new addresses for the fields. *)
+                val tupleAddrs = List.tabulate(tupleSize, fn _ => makeAddr())
+
+                (* Deal with the initial values for the loop variables. *)
+                fun replaceWithTuple [] = ([], [])
+                |   replaceWithTuple((original as ({value, addr, ...}, _)) :: args) =
+                    let
+                        (* To preserve the evaluation order we have to bind each of the original
+                           arguments to a variable then pass a reference to this variable as the initial
+                           value of the loop variable.  The exception is that we replace the argument
+                           we're tupling with new variables and the value of each of these new variables
+                           is the tuple field. *)
+                        val newAddr = makeAddr()
+                        val dec = Declar{ addr = newAddr, use = [], value = value }
+                        val ext = Extract(LoadLocal newAddr)
+                        val (restDecs, restArgs) = replaceWithTuple args
+
+                        fun mkFields([], _) = restArgs
+                        |   mkFields(a :: rest, n) =
+                                ({addr=a, value=mkInd(n, ext), use=[UseGeneral]}, GeneralType) ::
+                                    mkFields(rest, n+1)
+                    in
+                        if addr = addrForTuple
+                        then (dec :: restDecs, mkFields(tupleAddrs, 0))
+                        else (dec :: restDecs, original :: restArgs)
+                    end
+                val (decs, newArgs) = replaceWithTuple arguments
+
+                fun replaceLoop(Loop l) =
+                    let
+                        (* To preserve the evaluation order we need to bind the original arguments
+                           to variables.  Then the transformed arguments are the original arguments
+                           except for detupled argument which is replaced by its fields. *)
+                        val newAddresses = map (fn _ => makeAddr()) l
+                        val extractTuple = Extract(LoadLocal(List.nth(newAddresses, argumentNo)))
+                        val newDecs = ListPair.mapEq(fn((c, _), a) => Declar{addr=a, value=c, use=[]})(l, newAddresses)
+                        fun replaceArgs([], _) = []
+                        |   replaceArgs(arg :: rest, n) =
+                            if n = argumentNo
+                            then List.tabulate(tupleSize, fn i => (mkInd(i, extractTuple), GeneralType)) @ replaceArgs(rest, n+1)
+                            else arg :: replaceArgs(rest, n+1)
+                        val newLoopArgs = replaceArgs(l, 0)
+                        val () = if List.length newLoopArgs <> finalArgLength then raise InternalError "Bad length 1" else ()
+                        val loopBody = Loop newLoopArgs
+                    in
+                        SOME(mkEnv(newDecs, loopBody))
+                    end
+                |   replaceLoop(l as Lambda _) = SOME l (* Not inside functions *)
+                |   replaceLoop(l as BeginLoop _) = SOME l (* And not inside inner loops *)
+                |   replaceLoop _ = NONE
+
+                (* Inside the body we have to construct a tuple for the original argument.
+                   The simplifier will then replace every use of this with a reference to
+                   the new argument. *)
+                val tupleForBody = mkTuple(map(fn a => Extract(LoadLocal a)) tupleAddrs)
+                val newLoop =
+                    mkEnv([Declar{addr=addrForTuple, value=tupleForBody, use=[UseGeneral]}], mapCodetree replaceLoop loop)
+
+                val () = reprocess := true
+                val () = codeTreePrinter(PrettyString "Optimiser: replace loop")
+                val () = if List.length newArgs <> finalArgLength then raise InternalError "Bad length 2" else ()
+            in
+                mkEnv(decs, BeginLoop{loop=newLoop, arguments=newArgs})
+            end
+
+        |   NONE =>
+            BeginLoop{
+                    loop = optimise(context, loop, use),
+                    arguments =
+                        map (fn ({value, addr, use=argUse}, t) =>
+                                ({value=optimise(context, value, argUse),
+                                  addr=addr, use=argUse}, t))
+                            arguments}
+    end
+
 
     and optimiseNewenv (context as { reprocess, makeAddr, codeTreePrinter, ...}, envDecs, envExp, use) =
     let

--- a/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
+++ b/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
@@ -877,7 +877,20 @@ struct
             else SOME(Handle{exp=optGeneral context exp, handler=optGeneral context handler, exPacketAddr=exPacketAddr})
 
         |   doOptimise use (code as BeginLoop{loop, arguments}) =
+            (* If the result of the loop is only ever taken apart, push that down
+               before considering the arguments.  optFields walks this BeginLoop
+               again with [UseGeneral], which is where the detupling below then
+               happens, so we do not lose it. *)
+            if List.all(fn UseField _ => true | _ => false) use
+            then SOME(optFields(code, context, use))
+            else
             let
+                (* It's unsafe to detuple within a loop since it could potentially
+                   leave a Loop in a non tail position. Currently it's safe to
+                   generalize since the optFields check runs before this but still
+                   defensively swap into using [UseGeneral]. *)
+                val use = [UseGeneral]
+
                 (* If an argument is a tuple and always taken apart within the loop we should
                    replace it with arguments for the fields.  This is the same as detupling
                    function arguments.
@@ -982,17 +995,8 @@ struct
                     end
 
                 |   NONE =>
-                    (* If the result of the loop is taken apart we should push
-                       this down as well. *)
-                    if List.all(fn UseField _ => true | _ => false) use
-                    then SOME(optFields(code, context, use))
-                    else
-                    (* It's unsafe to detuple within a loop since it could potentially
-                       leave a Loop in a non tail position. Currently it's safe to
-                       generalize since the optFields check runs before this but still
-                       defensively swap into using [UseGeneral]. *)
                     SOME(BeginLoop{
-                            loop = optimise(context, loop, [UseGeneral]),
+                            loop = optimise(context, loop, use),
                             arguments =
                                 map (fn ({value, addr, use=argUse}, t) =>
                                         ({value=optimise(context, value, argUse),

--- a/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
+++ b/mlsource/MLCompiler/CodeTree/CodetreeOptimiser.ML
@@ -809,7 +809,10 @@ struct
 
     |   optimise (context as { reprocess, makeAddr, codeTreePrinter, ... }, use) (Newenv(envDecs, envExp)) =
         let
-            fun mapExp mapUse = mapCodetree (optimise(context, mapUse))
+            fun mapExp mapUse code =
+                case optimise (context, mapUse) code of
+                    SOME result => result
+                |   NONE => mapCodetree (optimise(context, [UseGeneral])) code
 
             fun mapbinding(Declar{value, addr, use}) = Declar{value=mapExp use value, addr=addr, use=use}
             |   mapbinding(RecDecs l) =
@@ -949,7 +952,13 @@ struct
             (* We duplicate the function arguments which could cause the size of the code
                to blow-up if they involve complicated expressions. *)
             fun pushFunction l =
-                 mapCodetree (optimise(context, use)) (Eval{function=l, argList=argList, resultType=resultType})
+            let
+                val code = Eval{function=l, argList=argList, resultType=resultType}
+            in
+                case optimise (context, use) code of
+                    SOME result => result
+                |   NONE => mapCodetree (optimise(context, [UseGeneral])) code
+            end
         in
             reprocess := true;
             codeTreePrinter(PrettyString "Optimiser: Eval(if...) => if ... Eval else Eval");
@@ -962,17 +971,27 @@ struct
         let
             val args = map (fn (c, t) => (optGeneral context c, t)) argList
             val argTuples = map #1 args
+            val optFunction =
+                case optimise (context, [UseApply(use, argTuples)]) function of
+                    SOME result => result
+                |   NONE => mapCodetree (optimise(context, [UseGeneral])) function
         in
             SOME(
                 Eval{
-                    function= mapCodetree (optimise (context, [UseApply(use, argTuples)])) function,
+                    function= optFunction,
                     argList=args, resultType = resultType
                 })
         end
 
     |   optimise (context, use) (Indirect{base, offset, indKind = IndTuple}) =
-        SOME(Indirect{base = mapCodetree (optimise(context, [UseField(offset, use)])) base,
-                      offset = offset, indKind = IndTuple})
+        let
+            val optBase =
+                case optimise (context, [UseField(offset, use)]) base of
+                    SOME result => result
+                |   NONE => mapCodetree (optimise(context, [UseGeneral])) base
+        in
+            SOME(Indirect{base = optBase, offset = offset, indKind = IndTuple})
+        end
 
     |   optimise (context, use) (code as Cond(i, t, e)) =
         (* If the result of the if-then-else is always taken apart as fields
@@ -994,6 +1013,11 @@ struct
 
     |   optimise (context as { makeAddr, reprocess, codeTreePrinter, ...}, use) (code as BeginLoop{loop, arguments}) =
         let
+            fun mapExp mapUse code =
+                case optimise (context, mapUse) code of
+                    SOME result => result
+                |   NONE => mapCodetree (optimise(context, [UseGeneral])) code
+
             (* If an argument is a tuple and always taken apart within the loop we should
                replace it with arguments for the fields.  This is the same as detupling
                function arguments.
@@ -1102,7 +1126,17 @@ struct
                    this down as well. *)
                 if List.all(fn UseField _ => true | _ => false) use
                 then SOME(optFields(code, context, use))
-                else NONE
+                else
+                (* It's unsafe to detuple within a loop since it could potentially leave
+                   a Loop in a non tail position. Currently it's safe to generalize since
+                   the optFields check runs before this but still defensively swap into
+                   using [UseGeneral]. *)
+                SOME(BeginLoop{
+                        loop = mapExp [UseGeneral] loop,
+                        arguments =
+                            map (fn ({value, addr, use=argUse}, t) =>
+                                    ({value=mapExp argUse value, addr=addr, use=argUse}, t))
+                                arguments})
         end
 
     |   optimise _ _ = NONE
@@ -1626,7 +1660,10 @@ struct
                     then (preOptCode, optimisedOnce, simpAgain)
                     else
                     let
-                        val postOptCode = mapCodetree (optimise(optContext, [UseExport])) preOptCode
+                        val postOptCode =
+                            case optimise (optContext, [UseExport]) preOptCode of
+                                SOME result => result
+                            |   NONE => mapCodetree (optimise(optContext, [UseGeneral])) preOptCode
                         (* Print the code after the optimiser. *)
                         val () = codeTreePrinter(Pretty.PrettyString "Output of optimiser")
                         val () = codeTreePrinter(BaseCodeTree.pretty postOptCode)

--- a/mlsource/MLCompiler/CodeTree/CodetreeRemoveRedundant.ML
+++ b/mlsource/MLCompiler/CodeTree/CodetreeRemoveRedundant.ML
@@ -4,12 +4,12 @@
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
     License version 2.1 as published by the Free Software Foundation.
-    
+
     This library is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
     Lesser General Public License for more details.
-    
+
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -33,11 +33,15 @@ struct
     open CodetreeFunctions
     exception InternalError = Misc.InternalError
 
-    (* This function annotates the tree with information about how variables are used.  This assists
-       the optimiser to choose the best alternative for code.  It also discards bindings that
-       are unused and side-effect-free.  These can arise as the result of optimiser constructing
-       bindings in case they are required.  That was originally its only function; hence the name. *)
-    fun cleanProc (pt, procUses: codeUse list, prev: int * codeUse list -> loadForm, recursiveRef: codeUse list -> unit, localCount, checkArg) =
+    type cleanContext =
+    {
+        locals:       codeUse list array,
+        prev:         int * codeUse list -> loadForm,
+        recursiveRef: codeUse list -> unit,
+        checkArg:     int * codeUse list -> unit
+    }
+
+    fun cleanProc (code, prev, localCount) =
     let
         (* Filter the use information so there is only a single instance of each kind of
            usage.  The usage lists can blow up.  See #197. *)
@@ -62,11 +66,13 @@ struct
         in
             List.app addUse uses
         end
-        
-        val locals = Array.array(localCount, [])
-        val addLocalUse: int -> codeUse list -> unit = addUsesToArray locals
 
-        fun cleanLambda(lambda as {body, isInline, name, argTypes, resultType, localCount, closure, ...}: lambdaForm,
+        (* This function annotates the tree with information about how variables are used.  This assists
+           the optimiser to choose the best alternative for code.  It also discards bindings that
+           are unused and side-effect-free.  These can arise as the result of optimiser constructing
+           bindings in case they are required.  That was originally its only function; hence the name. *)
+        fun cleanLambda(context: cleanContext,
+                        lambda as {body, isInline, name, argTypes, resultType, localCount, closure, ...}: lambdaForm,
                         lambdaUse) =
         let
             (* Rebuild the closure with the entries actually used. *)
@@ -78,7 +84,7 @@ struct
                     val ext = List.nth(closure, closureEntry)
                     (* Process the closure entry.  We need to do this to record the
                        usage information even if we have already seen this entry. *)
-                    val copied = cleanExtract(ext, clUse)
+                    val copied = cleanExtract(context, ext, clUse)
                 in
                     addToClosure closureUse copied
                 end
@@ -86,14 +92,14 @@ struct
             (* This array records the way the arguments are used inside the function. *)
             val argUses = Array.array (List.length argTypes, [])
             fun checkArg(addr, uses) = Array.update(argUses, addr, uses @ Array.sub(argUses, addr))
-            
+
             val recursiveRefRef = ref []
             fun addRef use = recursiveRefRef := use @ !recursiveRefRef
 
             val resultOfApps =
                 List.foldl
                     (fn (UseApply(l, _), r) => l @ r | (UseExport, r) => UseExport :: r | (_, r) => UseGeneral :: r) []
-            
+
             fun filter(true, true, []) = [UseExport, UseGeneral]
             |   filter(false, true, []) = [UseGeneral]
             |   filter(true, false, []) = [UseExport]
@@ -101,10 +107,14 @@ struct
             |   filter(_, isGen, UseExport :: l) = filter(true, isGen, l)
             |   filter(isExp, _, UseGeneral :: l) = filter(isExp, true, l)
             |   filter(isExp, isGen, a (* UseApply, UseField *) :: l) = a :: filter(isExp, isGen, l)
-            
+
             val bodyUse = filter(false, false, resultOfApps lambdaUse)
 
-            val bodyCode = cleanProc(body, bodyUse, lookup, addRef, localCount, checkArg)
+            val bodyContext =
+                { locals = Array.array(localCount, []), prev = lookup, recursiveRef = addRef,
+                  checkArg = checkArg } : cleanContext
+
+            val bodyCode = cleanCode(bodyContext, body, bodyUse)
             val recursiveApps = !recursiveRefRef
             (* If we have called this function somewhere and used the result that gives us a hint on the
                preferred result.  If the function is recursive, though, we can't assume anything
@@ -113,11 +123,11 @@ struct
                That in turn affects any functions whose results are used.  See Test138.ML.
                So, we check to see whether the result of recursive use has added anything to the
                original usage and reprocess the body if it has.
-               
+
                This has been extended to a general recursive case since the original
                single level case had a bug.  See Test191.ML. *)
             val recursiveResults = resultOfApps recursiveApps
-            
+
             (* CBottom is the "no/empty usage" element *)
             datatype canonical = CBottom | CExp | CGen | CApp of canonical | CFields of (int * canonical) list
 
@@ -142,14 +152,14 @@ struct
                 else (i1, mergecanon(u1, u2)) :: mergefield(tl1, tl2)
             |   mergefield([], l) = l
             |   mergefield(l, []) = l
-            
+
             and tocanonical [] = CBottom
             |   tocanonical (hd::tl) = List.foldl (fn (a, b) => mergecanon(tocanon a, b)) (tocanon hd) tl
 
         in
             if not (null recursiveResults) (* short cut *)
                 andalso tocanonical bodyUse <> tocanonical(recursiveResults @ bodyUse)
-            then cleanLambda(lambda, lambdaUse @ recursiveApps)
+            then cleanLambda(context, lambda, lambdaUse @ recursiveApps)
             else
                 let
                     val newClosure = extractClosure closureUse
@@ -164,30 +174,30 @@ struct
 
         (* Process a load from a variable.  Locals and arguments operate on the relevant array,
            closure entries involve a look-up *)
-        and cleanExtract(ext as LoadLocal addr, codeUse) =
+        and cleanExtract(context: cleanContext, ext as LoadLocal addr, codeUse) =
             (
                 (* Check we're actually adding to the usage. *)
                 null codeUse andalso raise InternalError "cleanExtract: empty usage";
-                addLocalUse addr codeUse;
+                addUsesToArray (#locals context) addr codeUse;
                 ext
             )
 
-        |   cleanExtract(ext as LoadArgument addr, codeUse) =
+        |   cleanExtract(context, ext as LoadArgument addr, codeUse) =
             (
-                checkArg(addr, codeUse);
+                #checkArg context (addr, codeUse);
                 ext
             )
 
-        |   cleanExtract(LoadClosure addr, codeUse) = prev(addr, codeUse)
-        
-        |   cleanExtract(LoadRecursive, codeUse) = (recursiveRef codeUse; LoadRecursive)
+        |   cleanExtract(context, LoadClosure addr, codeUse) = #prev context (addr, codeUse)
+
+        |   cleanExtract(context, LoadRecursive, codeUse) = (#recursiveRef context codeUse; LoadRecursive)
 
         (* Process a Newenv.  "codeUse" describes how the result value is used; an empty
            codeUse means the value is not required, in which case the final expression is
            cleaned for its side-effects only and the whole thing collapses to NONE if
            nothing survives.  For a required value (non-empty codeUse) the result is always
            SOME. *)
-        and cleanNewenv((decs, exp), codeUse) =
+        and cleanNewenv(context: cleanContext, (decs, exp), codeUse) =
             let
                 (* Process the declarations in reverse order.  A binding may be used in a
                    later declaration but apart from mutually-recursive functions no binding
@@ -200,11 +210,11 @@ struct
                     in
                         (* We can drop bindings that are unused if they have no side-effects.
                            If we retain the binding we must set at least one reference. *)
-                        case Array.sub(locals, addr) of
-                            [] => (case cleanDead value of
+                        case Array.sub(#locals context, addr) of
+                            [] => (case cleanDead(context, value) of
                                        NONE => processedRest
                                    |   SOME cleanedvalue => NullBinding cleanedvalue :: processedRest)
-                        |   uses => Declar{value=cleanCode(value, uses), addr=addr, use=uses} :: processedRest
+                        |   uses => Declar{value=cleanCode(context, value, uses), addr=addr, use=uses} :: processedRest
                     end
 
                 |   processDecs(RecDecs decs :: rest) =
@@ -226,19 +236,19 @@ struct
                          |  processMutuals(
                                 (this as {addr, lambda, ...}) :: rest, excluded, added) =
                             (
-                                case Array.sub(locals, addr) of
+                                case Array.sub(#locals context, addr) of
                                     [] => (* Put this on the excluded list. *)
                                         processMutuals(rest, this::excluded, added)
                                 |   useSoFar =>
                                         (* Process this then the rest of the list. *)
-                                        (addr, cleanLambda(lambda, UseGeneral :: useSoFar)) ::
+                                        (addr, cleanLambda(context, lambda, UseGeneral :: useSoFar)) ::
                                             processMutuals(rest, excluded, true)
                             )
                         val entriesUsed = processMutuals(decs, [], false)
                         (* Get all the uses now we're finished and have identified
                            all the recursive uses. *)
                         val processedDecs =
-                            map (fn(a, l) => {addr=a, lambda=l, use=Array.sub(locals, a)}) entriesUsed
+                            map (fn(a, l) => {addr=a, lambda=l, use=Array.sub(#locals context, a)}) entriesUsed
                     in
                         if null processedDecs
                         then processedRest
@@ -249,7 +259,7 @@ struct
                     let
                         val processedRest = processDecs rest
                     in
-                        case cleanDead exp of
+                        case cleanDead(context, exp) of
                             NONE => processedRest
                         |   SOME cleanedexp => NullBinding cleanedexp :: processedRest
                     end
@@ -258,7 +268,7 @@ struct
                     let
                         val processedRest = processDecs rest
                         val decUses =
-                            case Array.sub(locals, addr) of
+                            case Array.sub(#locals context, addr) of
                                 [] => if sideEffectFree setter then [] else [UseGeneral]
                             |   uses => uses
                     in
@@ -268,13 +278,13 @@ struct
                            we will never discard this even if the container is unused. *)
                         if null decUses
                         then processedRest (* Skip it *)
-                        else Container{setter=cleanCode (setter, [UseGeneral]), addr=addr, size=size, use=decUses} :: processedRest
+                        else Container{setter=cleanCode(context, setter, [UseGeneral]), addr=addr, size=size, use=decUses} :: processedRest
                     end
 
                 (* Process the expression first so any references it makes are marked,
                    then the bindings (in reverse order). *)
                 val processedExp =
-                    if null codeUse then cleanDead exp else SOME(cleanCode(exp, codeUse))
+                    if null codeUse then cleanDead(context, exp) else SOME(cleanCode(context, exp, codeUse))
             in
                 case (processDecs decs, processedExp) of
                     ([], NONE) => NONE
@@ -283,11 +293,11 @@ struct
 
         (* Clean a list of sub-expressions whose values are not required, keeping their
            side-effects in evaluation order.  NONE if they are all side-effect-free. *)
-        and cleanDeadList codes =
+        and cleanDeadList(context: cleanContext, codes) =
             let
                 fun keep [] = []
                 |   keep(c :: rest) =
-                        (case cleanDead c of NONE => keep rest | SOME r => NullBinding r :: keep rest)
+                        (case cleanDead(context, c) of NONE => keep rest | SOME r => NullBinding r :: keep rest)
             in
                 case keep codes of
                     [] => NONE
@@ -298,9 +308,9 @@ struct
            the usage of every exit branch (a tail-position expression that is not a Loop).
            When the result is unused (codeUse = []) those branches are cleaned dead, while
            the Loop jumps that continue iteration are kept. *)
-        and cleanBeginLoop((loop, arguments), codeUse) =
+        and cleanBeginLoop(context: cleanContext, (loop, arguments), codeUse) =
             let
-                val cleanBody = cleanCode(loop, codeUse)
+                val cleanBody = cleanCode(context, loop, codeUse)
                 (* Remove unused arguments.  They're unnecessary and may cause problems
                    later on. *)
                 fun filterUnused [] = ([], [])
@@ -308,10 +318,10 @@ struct
                     let
                         val (used, discards) = filterUnused args
                     in
-                        case Array.sub(locals, addr) of
+                        case Array.sub(#locals context, addr) of
                             [] => (* We only need to keep this if it might have a side-effect. *)
-                                (used, NullBinding(cleanCode(value, [UseGeneral])) :: discards)
-                        |   use => (({value=cleanCode(value, use), addr=addr, use=use}, t) :: used, discards)
+                                (used, NullBinding(cleanCode(context, value, [UseGeneral])) :: discards)
+                        |   use => (({value=cleanCode(context, value, use), addr=addr, use=use}, t) :: used, discards)
                     end
                 val (usedArgs, discards) = filterUnused arguments
             in
@@ -325,7 +335,7 @@ struct
                         in
                             (* We actually only need to keep this argument if it might have
                                a side-effect but keep it anyway. *)
-                            case Array.sub(locals, addr) of
+                            case Array.sub(#locals context, addr) of
                                 [] => (useArgs, NullBinding argVal :: discards)
                             |   _ => (arg :: useArgs, discards)
                         end
@@ -353,46 +363,46 @@ struct
         (* Clean an Eval.  Pass the usage down to the function so that if it is a
            variable it is marked as "called"; resultUse is how the call's result is
            used ([] when it is discarded). *)
-        and cleanEval({function, argList, resultType}, resultUse) =
+        and cleanEval(context, {function, argList, resultType}, resultUse) =
             let
-                val args = map (fn (c, t) => (cleanCode(c, [UseGeneral]), t)) argList
+                val args = map (fn (c, t) => (cleanCode(context, c, [UseGeneral]), t)) argList
                 val argTuples = map #1 args
             in
-                Eval{function = cleanCode(function, [UseApply(resultUse, argTuples)]),
+                Eval{function = cleanCode(context, function, [UseApply(resultUse, argTuples)]),
                      argList = args, resultType = resultType}
             end
 
         (* Process code whose result value is not required, retaining only what is needed
            for its side-effects.  Returns NONE if the code is side-effect-free (nothing to
            keep) or SOME of the residual code. *)
-        and cleanDead(Newenv nenv) = cleanNewenv(nenv, [])
+        and cleanDead(context: cleanContext, Newenv nenv) = cleanNewenv(context, nenv, [])
 
-        |   cleanDead(Cond(test, thenpt, elsept)) =
+        |   cleanDead(context, Cond(test, thenpt, elsept)) =
                 (
-                    case (cleanDead thenpt, cleanDead elsept) of
+                    case (cleanDead(context, thenpt), cleanDead(context, elsept)) of
                         (* Both arms side-effect-free: the branch selection is unobservable
                            when the result is discarded, so only the test's effects remain. *)
-                        (NONE, NONE) => cleanDead test
+                        (NONE, NONE) => cleanDead(context, test)
                     |   (t, e) =>
-                            SOME(Cond(cleanCode(test, [UseGeneral]),
+                            SOME(Cond(cleanCode(context, test, [UseGeneral]),
                                       Option.getOpt(t, CodeZero), Option.getOpt(e, CodeZero)))
                 )
 
             (* Building a tuple has no observable effect, so drop it and keep only the
                fields' side-effects, in order. *)
-        |   cleanDead(Tuple{fields, ...}) = cleanDeadList fields
+        |   cleanDead(context, Tuple{fields, ...}) = cleanDeadList(context, fields)
 
-        |   cleanDead(Indirect{base, ...}) = cleanDead base (* Indexing is side-effect-free. *)
+        |   cleanDead(context, Indirect{base, ...}) = cleanDead(context, base) (* Indexing is side-effect-free. *)
 
             (* A discarded handler must be kept even when the handler is pure, because
                catching and discarding an exception suppresses it.  But if the body cannot
                raise or have an effect the handler is unreachable and the whole thing dies. *)
-        |   cleanDead(Handle{exp, handler, exPacketAddr}) =
+        |   cleanDead(context, Handle{exp, handler, exPacketAddr}) =
                 (
-                    case cleanDead exp of
+                    case cleanDead(context, exp) of
                         NONE => NONE
                     |   SOME e =>
-                            SOME(Handle{exp=e, handler=Option.getOpt(cleanDead handler, CodeZero),
+                            SOME(Handle{exp=e, handler=Option.getOpt(cleanDead(context, handler), CodeZero),
                                         exPacketAddr=exPacketAddr})
                 )
 
@@ -400,71 +410,71 @@ struct
                sideEffectFree about a copy with constant operands (O(1), and it tracks
                codeProps).  If the operator is pure, drop it and keep the operand effects;
                otherwise keep the whole node. *)
-        |   cleanDead(code as Nullary _) = if sideEffectFree code then NONE else SOME code
+        |   cleanDead(_, code as Nullary _) = if sideEffectFree code then NONE else SOME code
 
-        |   cleanDead(code as Unary{oper, arg1}) =
+        |   cleanDead(context, code as Unary{oper, arg1}) =
                 if sideEffectFree(Unary{oper=oper, arg1=CodeZero})
-                then cleanDead arg1
-                else SOME(cleanCode(code, [UseGeneral]))
+                then cleanDead(context, arg1)
+                else SOME(cleanCode(context, code, [UseGeneral]))
 
-        |   cleanDead(code as Binary{oper, arg1, arg2}) =
+        |   cleanDead(context, code as Binary{oper, arg1, arg2}) =
                 if sideEffectFree(Binary{oper=oper, arg1=CodeZero, arg2=CodeZero})
-                then cleanDeadList[arg1, arg2]
-                else SOME(cleanCode(code, [UseGeneral]))
+                then cleanDeadList(context, [arg1, arg2])
+                else SOME(cleanCode(context, code, [UseGeneral]))
 
             (* A tag test, a load (immutable or mutable) and an allocation all have no
                effect of their own, so keep only their operand effects. *)
-        |   cleanDead(TagTest{test, ...}) = cleanDead test
+        |   cleanDead(context, TagTest{test, ...}) = cleanDead(context, test)
 
-        |   cleanDead(LoadOperation{address={base, index, ...}, ...}) =
-                cleanDeadList(base :: (case index of SOME i => [i] | NONE => []))
+        |   cleanDead(context, LoadOperation{address={base, index, ...}, ...}) =
+                cleanDeadList(context, base :: (case index of SOME i => [i] | NONE => []))
 
-        |   cleanDead(AllocateWordMemory{numWords, flags, initial}) =
-                cleanDeadList[numWords, flags, initial]
+        |   cleanDead(context, AllocateWordMemory{numWords, flags, initial}) =
+                cleanDeadList(context, [numWords, flags, initial])
 
             (* A block move is a store (keep); byte equality/compare is applicative. *)
-        |   cleanDead(code as BlockOperation{kind, sourceLeft, destRight, length}) =
+        |   cleanDead(context, code as BlockOperation{kind, sourceLeft, destRight, length}) =
                 (
                     case kind of
-                        BlockOpMove _ => SOME(cleanCode(code, [UseGeneral]))
+                        BlockOpMove _ => SOME(cleanCode(context, code, [UseGeneral]))
                     |   _ =>
                         let
                             fun addrParts{base, index, ...} =
                                 base :: (case index of SOME i => [i] | NONE => [])
                         in
-                            cleanDeadList(addrParts sourceLeft @ addrParts destRight @ [length])
+                            cleanDeadList(context, addrParts sourceLeft @ addrParts destRight @ [length])
                         end
                 )
 
             (* Arbitrary precision: the compiler treats its operands as just [arg1, arg2]
                (see evaluateInlining); shortCond and longCall are pure functions of them. *)
-        |   cleanDead(Arbitrary{arg1, arg2, ...}) = cleanDeadList[arg1, arg2]
+        |   cleanDead(context, Arbitrary{arg1, arg2, ...}) = cleanDeadList(context, [arg1, arg2])
 
             (* Keep the loop, but clean its body dead: every exit branch (a tail-position
                expression that is not a Loop) has its now-unused result discarded, and any
                loop argument that only fed such a branch is dropped. *)
-        |   cleanDead(BeginLoop{loop, arguments}) = SOME(cleanBeginLoop((loop, arguments), []))
+        |   cleanDead(context, BeginLoop{loop, arguments}) = SOME(cleanBeginLoop(context, (loop, arguments), []))
 
             (* Keep the call (it has an effect), but tell the function its result is
                unused: mark it UseApply with an empty result usage.  A function whose
                call sites discard the result then has bodyUse = [] in cleanLambda and
                so has its body dead-cleaned. *)
-        |   cleanDead(Eval eval) = SOME(cleanEval(eval, []))
+        |   cleanDead(context, Eval eval) = SOME(cleanEval(context, eval, []))
 
-        |   cleanDead(Extract _) = NONE
-        |   cleanDead(Constnt _) = NONE
-        |   cleanDead(Lambda _) = NONE
+        |   cleanDead(_, Extract _) = NONE
+        |   cleanDead(_, Constnt _) = NONE
+        |   cleanDead(_, Lambda _) = NONE
 
-            (* Everything else — Raise, Loop, StoreOperation, SetContainer — always carries
-               a side-effect, so keep it with the result discarded. *)
-        |   cleanDead code = SOME(cleanCode(code, [UseGeneral]))
+            (* Everything else — Raise, Loop, StoreOperation, SetContainer — always carries a
+               side-effect, so keep it with the result discarded. *)
+        |   cleanDead(context, code) = SOME(cleanCode(context, code, [UseGeneral]))
 
-        and cleanCode (code, codeUse) =
+        and cleanCode (context: cleanContext, code, codeUse) =
         let
-            fun doClean codeUse (Newenv nenv) = SOME(Option.getOpt(cleanNewenv(nenv, codeUse), CodeZero))
+            fun doClean codeUse (Newenv nenv) = SOME(Option.getOpt(cleanNewenv(context, nenv, codeUse), CodeZero))
 
                 (* Reference to a binding. *)
-            |   doClean codeUse (Extract ext) = SOME(Extract(cleanExtract(ext, codeUse)))
+            |   doClean codeUse (Extract ext) = SOME(Extract(cleanExtract(context, ext, codeUse)))
 
                 (* Select a field from a tuple or container.  We can't do this for selection from datatypes because
                    some fields may not be present on all paths. *)
@@ -475,7 +485,7 @@ struct
                 in
                     case indKind of
                          IndVariant => NONE
-                    |    _ => SOME(Indirect{base=cleanCode(base, [UseField(offset, codeUse)]), offset=offset, indKind = indKind})
+                    |    _ => SOME(Indirect{base=cleanCode(context, base, [UseField(offset, codeUse)]), offset=offset, indKind = indKind})
                 end
 
             |   doClean codeUse (Tuple{ fields, isVariant = false}) =
@@ -489,43 +499,40 @@ struct
 
                     fun fieldUses n =
                         List.foldl(fieldUse n) [] codeUse
-                            
+
                     fun processField([], _) = []
                     |   processField(hd::tl, n) =
-                            cleanCode(hd, fieldUses n) :: processField(tl, n+1)
+                            cleanCode(context, hd, fieldUses n) :: processField(tl, n+1)
                 in
                     SOME(Tuple{ fields = processField(fields, 0), isVariant = false})
                 end
 
-            |   doClean codeUse (Lambda lam) = SOME(Lambda(cleanLambda(lam, codeUse)))
+            |   doClean codeUse (Lambda lam) = SOME(Lambda(cleanLambda(context, lam, codeUse)))
 
-            |   doClean codeUse (Eval eval) = SOME(cleanEval(eval, codeUse))
+            |   doClean codeUse (Eval eval) = SOME(cleanEval(context, eval, codeUse))
 
             |   doClean codeUse (Cond(i, t, e)) =
-                    SOME(Cond(cleanCode(i, [UseGeneral]), cleanCode(t, codeUse), cleanCode(e, codeUse)))
+                    SOME(Cond(cleanCode(context, i, [UseGeneral]), cleanCode(context, t, codeUse), cleanCode(context, e, codeUse)))
 
-            |   doClean use (BeginLoop{loop, arguments}) = SOME(cleanBeginLoop((loop, arguments), use))
+            |   doClean use (BeginLoop{loop, arguments}) = SOME(cleanBeginLoop(context, (loop, arguments), use))
 
             |   doClean _ _ = NONE (* Anything else *)
-            
+
         in
             (* If we recognise this as a special case we use the result otherwise
                we process it as a general value using UseGeneral as the usage. *)
             if null codeUse
-            then Option.getOpt(cleanDead code,CodeZero)
+            then Option.getOpt(cleanDead(context, code), CodeZero)
             else
             (case doClean codeUse code of
                 SOME result => result
             |   NONE => mapCodetree (doClean [UseGeneral]) code)
         end
-
     in
-        cleanCode (pt, procUses)
-    end (* cleanProc *)
-
-    val cleanProc =
-        fn (code, prev, localCount) =>
-            cleanProc(code, [UseExport], fn (i, _) => prev i, fn _ => (), localCount, fn _ => ())
+        cleanCode({ locals = Array.array(localCount, []), prev = fn (i, _) => prev i,
+                    recursiveRef = fn _ => (), checkArg = fn _ => () },
+                  code, [UseExport])
+    end
 
     structure Sharing =
     struct

--- a/mlsource/MLCompiler/CodeTree/CodetreeRemoveRedundant.ML
+++ b/mlsource/MLCompiler/CodeTree/CodetreeRemoveRedundant.ML
@@ -179,109 +179,207 @@ struct
         
         |   cleanExtract(LoadRecursive, codeUse) = (recursiveRef codeUse; LoadRecursive)
 
+        (* Process a Newenv.  "codeUse" describes how the result value is used; an empty
+           codeUse means the value is not required, in which case the final expression is
+           cleaned for its side-effects only and the whole thing collapses to NONE if
+           nothing survives.  For a required value (non-empty codeUse) the result is always
+           SOME. *)
+        and cleanNewenv((decs, exp), codeUse) =
+            let
+                (* Process the declarations in reverse order.  A binding may be used in a
+                   later declaration but apart from mutually-recursive functions no binding
+                   can be used in an earlier one. *)
+                fun processDecs [] = []
+
+                |   processDecs(Declar{value, addr, ...} :: rest) =
+                    let
+                        val processedRest = processDecs rest
+                    in
+                        (* We can drop bindings that are unused if they have no side-effects.
+                           If we retain the binding we must set at least one reference. *)
+                        case Array.sub(locals, addr) of
+                            [] => (case cleanDead value of
+                                       NONE => processedRest
+                                   |   SOME cleanedvalue => NullBinding cleanedvalue :: processedRest)
+                        |   uses => Declar{value=cleanCode(value, uses), addr=addr, use=uses} :: processedRest
+                    end
+
+                |   processDecs(RecDecs decs :: rest) =
+                    let
+                        val processedRest = processDecs rest
+                        (* We now know the entries that have actually been used
+                           in the rest of the code.  We need to include those
+                           declarations and any that they use.
+                           The result we pass down may well exclude some or all
+                           recursive uses.  We need to include UseGeneral in
+                           the result for safety. *)
+                        fun processMutuals([], excluded, true) =
+                                (* If we have included a function in this
+                                   pass we have to reprocess the list of
+                                   those we excluded before. *)
+                                processMutuals(excluded, [], false)
+                         |  processMutuals([], _, false) =
+                                (* We didn't add anything more - finish *) []
+                         |  processMutuals(
+                                (this as {addr, lambda, ...}) :: rest, excluded, added) =
+                            (
+                                case Array.sub(locals, addr) of
+                                    [] => (* Put this on the excluded list. *)
+                                        processMutuals(rest, this::excluded, added)
+                                |   useSoFar =>
+                                        (* Process this then the rest of the list. *)
+                                        (addr, cleanLambda(lambda, UseGeneral :: useSoFar)) ::
+                                            processMutuals(rest, excluded, true)
+                            )
+                        val entriesUsed = processMutuals(decs, [], false)
+                        (* Get all the uses now we're finished and have identified
+                           all the recursive uses. *)
+                        val processedDecs =
+                            map (fn(a, l) => {addr=a, lambda=l, use=Array.sub(locals, a)}) entriesUsed
+                    in
+                        if null processedDecs
+                        then processedRest
+                        else RecDecs processedDecs :: processedRest
+                    end
+
+                |   processDecs(NullBinding exp :: rest) =
+                    let
+                        val processedRest = processDecs rest
+                    in
+                        case cleanDead exp of
+                            NONE => processedRest
+                        |   SOME cleanedexp => NullBinding cleanedexp :: processedRest
+                    end
+
+                |   processDecs(Container{setter, size, addr, ...} :: rest) =
+                    let
+                        val processedRest = processDecs rest
+                        val decUses =
+                            case Array.sub(locals, addr) of
+                                [] => if sideEffectFree setter then [] else [UseGeneral]
+                            |   uses => uses
+                    in
+                        (* We can drop bindings that are unused if they have no side-effects.
+                           If we retain the binding we must set at least one reference. *)
+                        (* Currently SetContainer is treated as having a side-effect so
+                           we will never discard this even if the container is unused. *)
+                        if null decUses
+                        then processedRest (* Skip it *)
+                        else Container{setter=cleanCode (setter, [UseGeneral]), addr=addr, size=size, use=decUses} :: processedRest
+                    end
+
+                (* Process the expression first so any references it makes are marked,
+                   then the bindings (in reverse order). *)
+                val processedExp =
+                    if null codeUse then cleanDead exp else SOME(cleanCode(exp, codeUse))
+            in
+                case (processDecs decs, processedExp) of
+                    ([], NONE) => NONE
+                |   (decs, expOpt) => SOME(mkEnv(decs, Option.getOpt(expOpt, CodeZero)))
+            end
+
+        (* Clean a list of sub-expressions whose values are not required, keeping their
+           side-effects in evaluation order.  NONE if they are all side-effect-free. *)
+        and cleanDeadList codes =
+            let
+                fun keep [] = []
+                |   keep(c :: rest) =
+                        (case cleanDead c of NONE => keep rest | SOME r => NullBinding r :: keep rest)
+            in
+                case keep codes of
+                    [] => NONE
+                |   binds => SOME(mkEnv(binds, CodeZero))
+            end
+
+        (* Process code whose result value is not required, retaining only what is needed
+           for its side-effects.  Returns NONE if the code is side-effect-free (nothing to
+           keep) or SOME of the residual code. *)
+        and cleanDead(Newenv nenv) = cleanNewenv(nenv, [])
+
+        |   cleanDead(Cond(test, thenpt, elsept)) =
+                (
+                    case (cleanDead thenpt, cleanDead elsept) of
+                        (* Both arms side-effect-free: the branch selection is unobservable
+                           when the result is discarded, so only the test's effects remain. *)
+                        (NONE, NONE) => cleanDead test
+                    |   (t, e) =>
+                            SOME(Cond(cleanCode(test, [UseGeneral]),
+                                      Option.getOpt(t, CodeZero), Option.getOpt(e, CodeZero)))
+                )
+
+            (* Building a tuple has no observable effect, so drop it and keep only the
+               fields' side-effects, in order. *)
+        |   cleanDead(Tuple{fields, ...}) = cleanDeadList fields
+
+        |   cleanDead(Indirect{base, ...}) = cleanDead base (* Indexing is side-effect-free. *)
+
+            (* A discarded handler must be kept even when the handler is pure, because
+               catching and discarding an exception suppresses it.  But if the body cannot
+               raise or have an effect the handler is unreachable and the whole thing dies. *)
+        |   cleanDead(Handle{exp, handler, exPacketAddr}) =
+                (
+                    case cleanDead exp of
+                        NONE => NONE
+                    |   SOME e =>
+                            SOME(Handle{exp=e, handler=Option.getOpt(cleanDead handler, CodeZero),
+                                        exPacketAddr=exPacketAddr})
+                )
+
+            (* Operation nodes.  Decide whether the operator itself has an effect by calling
+               sideEffectFree about a copy with constant operands (O(1), and it tracks
+               codeProps).  If the operator is pure, drop it and keep the operand effects;
+               otherwise keep the whole node. *)
+        |   cleanDead(code as Nullary _) = if sideEffectFree code then NONE else SOME code
+
+        |   cleanDead(code as Unary{oper, arg1}) =
+                if sideEffectFree(Unary{oper=oper, arg1=CodeZero})
+                then cleanDead arg1
+                else SOME(cleanCode(code, [UseGeneral]))
+
+        |   cleanDead(code as Binary{oper, arg1, arg2}) =
+                if sideEffectFree(Binary{oper=oper, arg1=CodeZero, arg2=CodeZero})
+                then cleanDeadList[arg1, arg2]
+                else SOME(cleanCode(code, [UseGeneral]))
+
+            (* A tag test, a load (immutable or mutable) and an allocation all have no
+               effect of their own, so keep only their operand effects. *)
+        |   cleanDead(TagTest{test, ...}) = cleanDead test
+
+        |   cleanDead(LoadOperation{address={base, index, ...}, ...}) =
+                cleanDeadList(base :: (case index of SOME i => [i] | NONE => []))
+
+        |   cleanDead(AllocateWordMemory{numWords, flags, initial}) =
+                cleanDeadList[numWords, flags, initial]
+
+            (* A block move is a store (keep); byte equality/compare is applicative. *)
+        |   cleanDead(code as BlockOperation{kind, sourceLeft, destRight, length}) =
+                (
+                    case kind of
+                        BlockOpMove _ => SOME(cleanCode(code, [UseGeneral]))
+                    |   _ =>
+                        let
+                            fun addrParts{base, index, ...} =
+                                base :: (case index of SOME i => [i] | NONE => [])
+                        in
+                            cleanDeadList(addrParts sourceLeft @ addrParts destRight @ [length])
+                        end
+                )
+
+            (* Arbitrary precision: the compiler treats its operands as just [arg1, arg2]
+               (see evaluateInlining); shortCond and longCall are pure functions of them. *)
+        |   cleanDead(Arbitrary{arg1, arg2, ...}) = cleanDeadList[arg1, arg2]
+
+        |   cleanDead(Extract _) = NONE
+        |   cleanDead(Constnt _) = NONE
+        |   cleanDead(Lambda _) = NONE
+
+            (* Everything else — Eval, Raise, BeginLoop, Loop, StoreOperation, SetContainer
+               — always carries a side-effect, so keep it with the result discarded. *)
+        |   cleanDead code = SOME(cleanCode(code, [UseGeneral]))
+
         and cleanCode (code, codeUse) =
         let
-            fun doClean codeUse (Newenv(decs, exp)) =
-                let
-                    (* First process the expression so as to mark any references it makes. *)
-                    val processedExp = cleanCode (exp, codeUse)
-                
-                    (* Process the declarations in reverse order.  A binding may be used in
-                       a later declaration but apart from mutually-recursive functions no binding
-                       can be used in an earlier one. *)
-                    fun processDecs [] = []
-
-                    |   processDecs(Declar{value, addr, ...} :: rest) =
-                        let
-                            val processedRest = processDecs rest
-                            val decUses =
-                                case Array.sub(locals, addr) of
-                                    [] => if sideEffectFree value then [] else [UseGeneral]
-                                |   uses => uses
-                        in
-                            (* We can drop bindings that are unused if they have no side-effects.
-                               If we retain the binding we must set at least one reference. *)
-                            if null decUses
-                            then processedRest (* Skip it *)
-                            else
-                            let
-                                val cleanvalue =
-                                    case value of
-                                        Lambda lambda => Lambda(cleanLambda(lambda, decUses))
-                                    |   value => cleanCode (value, decUses)
-                            in
-                                Declar{value=cleanvalue, addr=addr, use=decUses} :: processedRest
-                            end
-                        end
-
-                    |   processDecs(RecDecs decs :: rest) =
-                        let
-                            val processedRest = processDecs rest
-                            (* We now know the entries that have actually been used
-                               in the rest of the code.  We need to include those
-                               declarations and any that they use.
-                               The result we pass down may well exclude some or all
-                               recursive uses.  We need to include UseGeneral in
-                               the result for safety. *)
-                            fun processMutuals([], excluded, true) =
-                                    (* If we have included a function in this
-                                       pass we have to reprocess the list of
-                                       those we excluded before. *)
-                                    processMutuals(excluded, [], false)
-                             |  processMutuals([], _, false) =
-                                    (* We didn't add anything more - finish *) []
-                             |  processMutuals(
-                                    (this as {addr, lambda, ...}) :: rest, excluded, added) =
-                                (
-                                    case Array.sub(locals, addr) of
-                                        [] => (* Put this on the excluded list. *)
-                                            processMutuals(rest, this::excluded, added)
-                                    |   useSoFar =>
-                                            (* Process this then the rest of the list. *)
-                                            (addr, cleanLambda(lambda, UseGeneral :: useSoFar)) ::
-                                                processMutuals(rest, excluded, true)
-                                )
-                            val entriesUsed = processMutuals(decs, [], false)
-                            (* Get all the uses now we're finished and have identified
-                               all the recursive uses. *)
-                            val processedDecs =
-                                map (fn(a, l) => {addr=a, lambda=l, use=Array.sub(locals, a)}) entriesUsed
-                        in
-                            if null processedDecs
-                            then processedRest
-                            else RecDecs processedDecs :: processedRest
-                        end
-
-                    |   processDecs(NullBinding exp :: rest) =
-                        let
-                            val processedRest = processDecs rest
-                        in
-                            if sideEffectFree exp
-                            then processedRest
-                            else NullBinding(cleanCode(exp, [UseGeneral])) :: processedRest
-                        end
-
-                    |   processDecs(Container{setter, size, addr, ...} :: rest) =
-                        let
-                            val processedRest = processDecs rest
-                            val decUses =
-                                case Array.sub(locals, addr) of
-                                    [] => if sideEffectFree setter then [] else [UseGeneral]
-                                |   uses => uses
-                        in
-                            (* We can drop bindings that are unused if they have no side-effects.
-                               If we retain the binding we must set at least one reference. *)
-                            (* Currently SetContainer is treated as having a side-effect so
-                               we will never discard this even if the container is unused. *)
-                            if null decUses
-                            then processedRest (* Skip it *)
-                            else Container{setter=cleanCode (setter, [UseGeneral]), addr=addr, size=size, use=decUses} :: processedRest
-                        end
-
-                    val processedDecs = processDecs decs
-                in
-                    SOME(mkEnv(processedDecs, processedExp))
-                end (* Newenv *)
+            fun doClean codeUse (Newenv nenv) = SOME(Option.getOpt(cleanNewenv(nenv, codeUse), CodeZero))
 
                 (* Reference to a binding. *)
             |   doClean codeUse (Extract ext) = SOME(Extract(cleanExtract(ext, codeUse)))
@@ -308,12 +406,7 @@ struct
                     |   fieldUse _ (use, tl) = use :: tl
 
                     fun fieldUses n =
-                        (* For the moment, if we find that the field is not used we set the
-                           usage to UseGeneral.  I'm not convinced it would be safe to
-                           discard anything in the expression at this point. *)
-                        case List.foldl(fieldUse n) [] codeUse of
-                            [] => [UseGeneral]
-                        |   other => other
+                        List.foldl(fieldUse n) [] codeUse
                             
                     fun processField([], _) = []
                     |   processField(hd::tl, n) =
@@ -398,9 +491,12 @@ struct
         in
             (* If we recognise this as a special case we use the result otherwise
                we process it as a general value using UseGeneral as the usage. *)
-            case doClean codeUse code of
+            if null codeUse
+            then Option.getOpt(cleanDead code,CodeZero)
+            else
+            (case doClean codeUse code of
                 SOME result => result
-            |   NONE => mapCodetree (doClean [UseGeneral]) code
+            |   NONE => mapCodetree (doClean [UseGeneral]) code)
         end
 
     in

--- a/mlsource/MLCompiler/CodeTree/CodetreeRemoveRedundant.ML
+++ b/mlsource/MLCompiler/CodeTree/CodetreeRemoveRedundant.ML
@@ -291,6 +291,62 @@ struct
                 |   binds => SOME(mkEnv(binds, CodeZero))
             end
 
+        (* Process a BeginLoop.  "codeUse" is how the loop's result value is used, which is
+           the usage of every exit branch (a tail-position expression that is not a Loop).
+           When the result is unused (codeUse = []) those branches are cleaned dead, while
+           the Loop jumps that continue iteration are kept. *)
+        and cleanBeginLoop((loop, arguments), codeUse) =
+            let
+                val cleanBody = cleanCode(loop, codeUse)
+                (* Remove unused arguments.  They're unnecessary and may cause problems
+                   later on. *)
+                fun filterUnused [] = ([], [])
+                |   filterUnused(({value, addr, ...}, t) :: args) =
+                    let
+                        val (used, discards) = filterUnused args
+                    in
+                        case Array.sub(locals, addr) of
+                            [] => (* We only need to keep this if it might have a side-effect. *)
+                                (used, NullBinding(cleanCode(value, [UseGeneral])) :: discards)
+                        |   use => (({value=cleanCode(value, use), addr=addr, use=use}, t) :: used, discards)
+                    end
+                val (usedArgs, discards) = filterUnused arguments
+            in
+                if not(null discards)
+                then
+                let
+                    fun splitArgs([], []) = ([], [])
+                    |   splitArgs((arg as (argVal, _)) :: args, ({addr, ...}, _) :: arguments) =
+                        let
+                            val (useArgs, discards) = splitArgs(args, arguments)
+                        in
+                            (* We actually only need to keep this argument if it might have
+                               a side-effect but keep it anyway. *)
+                            case Array.sub(locals, addr) of
+                                [] => (useArgs, NullBinding argVal :: discards)
+                            |   _ => (arg :: useArgs, discards)
+                        end
+                    |   splitArgs _ = raise InternalError "splitArgs"
+
+                    fun filterLoopArgs(Loop l) =
+                        let
+                            val (useArgs, discards) = splitArgs(l, arguments)
+                        in
+                            SOME(Newenv(discards, Loop useArgs))
+                        end
+                        (* Don't descend into functions or inner loops. *)
+                    |   filterLoopArgs(instr as Lambda _) = SOME instr
+                    |   filterLoopArgs(instr as BeginLoop _) = SOME instr
+                    |   filterLoopArgs _ = NONE
+
+                    val newLoop =
+                        BeginLoop {loop = mapCodetree filterLoopArgs cleanBody, arguments = usedArgs}
+                in
+                    Newenv(discards, newLoop)
+                end
+                else BeginLoop {loop = cleanBody, arguments = usedArgs}
+            end
+
         (* Process code whose result value is not required, retaining only what is needed
            for its side-effects.  Returns NONE if the code is side-effect-free (nothing to
            keep) or SOME of the residual code. *)
@@ -369,12 +425,17 @@ struct
                (see evaluateInlining); shortCond and longCall are pure functions of them. *)
         |   cleanDead(Arbitrary{arg1, arg2, ...}) = cleanDeadList[arg1, arg2]
 
+            (* Keep the loop, but clean its body dead: every exit branch (a tail-position
+               expression that is not a Loop) has its now-unused result discarded, and any
+               loop argument that only fed such a branch is dropped. *)
+        |   cleanDead(BeginLoop{loop, arguments}) = SOME(cleanBeginLoop((loop, arguments), []))
+
         |   cleanDead(Extract _) = NONE
         |   cleanDead(Constnt _) = NONE
         |   cleanDead(Lambda _) = NONE
 
-            (* Everything else — Eval, Raise, BeginLoop, Loop, StoreOperation, SetContainer
-               — always carries a side-effect, so keep it with the result discarded. *)
+            (* Everything else — Eval, Raise, Loop, StoreOperation, SetContainer — always
+               carries a side-effect, so keep it with the result discarded. *)
         |   cleanDead code = SOME(cleanCode(code, [UseGeneral]))
 
         and cleanCode (code, codeUse) =
@@ -434,58 +495,8 @@ struct
             |   doClean codeUse (Cond(i, t, e)) =
                     SOME(Cond(cleanCode(i, [UseGeneral]), cleanCode(t, codeUse), cleanCode(e, codeUse)))
 
-            |   doClean use (BeginLoop{loop, arguments}) =
-                let
-                    val cleanBody = cleanCode(loop, use)
-                    (* Remove unused arguments.  They're unnecessary and may cause problems
-                       later on. *)
-                    fun filterUnused [] = ([], [])
-                    |   filterUnused(({value, addr, ...}, t) :: args) =
-                        let
-                            val (used, discards) = filterUnused args
-                        in
-                            case Array.sub(locals, addr) of
-                                [] => (* We only need to keep this if it might have a side-effect. *)
-                                    (used, NullBinding(cleanCode(value, [UseGeneral])) :: discards)
-                            |   use => (({value=cleanCode(value, use), addr=addr, use=use}, t) :: used, discards)
-                        end
-                    val (usedArgs, discards) = filterUnused arguments
-                in
-                    if not(null discards)
-                    then
-                    let
-                        fun splitArgs([], []) = ([], [])
-                        |   splitArgs((arg as (argVal, _)) :: args, ({addr, ...}, _) :: arguments) =
-                            let
-                                val (useArgs, discards) = splitArgs(args, arguments)
-                            in
-                                (* We actually only need to keep this argument if it might have
-                                   a side-effect but keep it anyway. *)
-                                case Array.sub(locals, addr) of
-                                    [] => (useArgs, NullBinding argVal :: discards)
-                                |   _ => (arg :: useArgs, discards)
-                            end
-                        |   splitArgs _ = raise InternalError "splitArgs"
+            |   doClean use (BeginLoop{loop, arguments}) = SOME(cleanBeginLoop((loop, arguments), use))
 
-                        fun filterLoopArgs(Loop l) =
-                            let
-                                val (useArgs, discards) = splitArgs(l, arguments)
-                            in
-                                SOME(Newenv(discards, Loop useArgs))
-                            end
-                            (* Don't descend into functions or inner loops. *)
-                        |   filterLoopArgs(instr as Lambda _) = SOME instr
-                        |   filterLoopArgs(instr as BeginLoop _) = SOME instr
-                        |   filterLoopArgs _ = NONE
-
-                        val newLoop =
-                            BeginLoop {loop = mapCodetree filterLoopArgs cleanBody, arguments = usedArgs}
-                    in
-                        SOME(Newenv(discards, newLoop))
-                    end
-                    else SOME(BeginLoop {loop = cleanBody, arguments = usedArgs})
-                end
-        
             |   doClean _ _ = NONE (* Anything else *)
             
         in

--- a/mlsource/MLCompiler/CodeTree/CodetreeRemoveRedundant.ML
+++ b/mlsource/MLCompiler/CodeTree/CodetreeRemoveRedundant.ML
@@ -514,6 +514,11 @@ struct
             |   doClean codeUse (Cond(i, t, e)) =
                     SOME(Cond(cleanCode(context, i, [UseGeneral]), cleanCode(context, t, codeUse), cleanCode(context, e, codeUse)))
 
+            |   doClean codeUse (Handle{exp, handler, exPacketAddr}) =
+                    SOME(Handle{exp = cleanCode(context, exp, codeUse),
+                                handler = cleanCode(context, handler, codeUse),
+                                exPacketAddr = exPacketAddr})
+
             |   doClean use (BeginLoop{loop, arguments}) = SOME(cleanBeginLoop(context, (loop, arguments), use))
 
             |   doClean _ _ = NONE (* Anything else *)

--- a/mlsource/MLCompiler/CodeTree/CodetreeRemoveRedundant.ML
+++ b/mlsource/MLCompiler/CodeTree/CodetreeRemoveRedundant.ML
@@ -118,14 +118,17 @@ struct
                single level case had a bug.  See Test191.ML. *)
             val recursiveResults = resultOfApps recursiveApps
             
-            datatype canonical = CExp | CGen | CApp of canonical | CFields of (int * canonical) list
-            
+            (* CBottom is the "no/empty usage" element *)
+            datatype canonical = CBottom | CExp | CGen | CApp of canonical | CFields of (int * canonical) list
+
             fun tocanon UseExport = CExp
             |   tocanon UseGeneral = CGen
             |   tocanon (UseApply(apps, _)) = CApp(tocanonical apps)
             |   tocanon (UseField(i, uses)) = CFields[(i, tocanonical uses)]
 
-            and mergecanon(CExp, _) = CExp
+            and mergecanon(CBottom, y) = y
+            |   mergecanon(x, CBottom) = x
+            |   mergecanon(CExp, _) = CExp
             |   mergecanon(_, CExp) = CExp
             |   mergecanon(CGen, _) = CGen
             |   mergecanon(_, CGen) = CGen
@@ -140,7 +143,7 @@ struct
             |   mergefield([], l) = l
             |   mergefield(l, []) = l
             
-            and tocanonical [] = CGen
+            and tocanonical [] = CBottom
             |   tocanonical (hd::tl) = List.foldl (fn (a, b) => mergecanon(tocanon a, b)) (tocanon hd) tl
 
         in
@@ -347,6 +350,18 @@ struct
                 else BeginLoop {loop = cleanBody, arguments = usedArgs}
             end
 
+        (* Clean an Eval.  Pass the usage down to the function so that if it is a
+           variable it is marked as "called"; resultUse is how the call's result is
+           used ([] when it is discarded). *)
+        and cleanEval({function, argList, resultType}, resultUse) =
+            let
+                val args = map (fn (c, t) => (cleanCode(c, [UseGeneral]), t)) argList
+                val argTuples = map #1 args
+            in
+                Eval{function = cleanCode(function, [UseApply(resultUse, argTuples)]),
+                     argList = args, resultType = resultType}
+            end
+
         (* Process code whose result value is not required, retaining only what is needed
            for its side-effects.  Returns NONE if the code is side-effect-free (nothing to
            keep) or SOME of the residual code. *)
@@ -430,12 +445,18 @@ struct
                loop argument that only fed such a branch is dropped. *)
         |   cleanDead(BeginLoop{loop, arguments}) = SOME(cleanBeginLoop((loop, arguments), []))
 
+            (* Keep the call (it has an effect), but tell the function its result is
+               unused: mark it UseApply with an empty result usage.  A function whose
+               call sites discard the result then has bodyUse = [] in cleanLambda and
+               so has its body dead-cleaned. *)
+        |   cleanDead(Eval eval) = SOME(cleanEval(eval, []))
+
         |   cleanDead(Extract _) = NONE
         |   cleanDead(Constnt _) = NONE
         |   cleanDead(Lambda _) = NONE
 
-            (* Everything else — Eval, Raise, Loop, StoreOperation, SetContainer — always
-               carries a side-effect, so keep it with the result discarded. *)
+            (* Everything else — Raise, Loop, StoreOperation, SetContainer — always carries
+               a side-effect, so keep it with the result discarded. *)
         |   cleanDead code = SOME(cleanCode(code, [UseGeneral]))
 
         and cleanCode (code, codeUse) =
@@ -478,19 +499,7 @@ struct
 
             |   doClean codeUse (Lambda lam) = SOME(Lambda(cleanLambda(lam, codeUse)))
 
-            |   doClean codeUse (Eval{function, argList, resultType}) =
-                (* As with Indirect we try to pass this information down so that if
-                   the function is a variable it will be marked as "called". *)
-                let
-                    val args = map (fn (c, t) => (cleanCode(c, [UseGeneral]), t)) argList
-                    val argTuples = map #1 args
-                in
-                    SOME(
-                        Eval{
-                            function=cleanCode(function, [UseApply(codeUse, argTuples)]),
-                            argList=args, resultType = resultType
-                        })
-                end
+            |   doClean codeUse (Eval eval) = SOME(cleanEval(eval, codeUse))
 
             |   doClean codeUse (Cond(i, t, e)) =
                     SOME(Cond(cleanCode(i, [UseGeneral]), cleanCode(t, codeUse), cleanCode(e, codeUse)))


### PR DESCRIPTION
This PR is done such that it's dependent on #297 starts at c9e9ae0dfb21d5fadb1c1269305d38234d7c7ff4.
It fixes questionable use of mapCodetree which leaked uses instead of conservatively resetting back into [UseGeneral]. Also optimise some subtrees missed see 9b62f81e81362c99cbecc15f4a0fbd3784370b4b 19dd39efad02c976d4cac126adf50e7692f69ecb and f5221803ffa9f3878880efb462cdc9eea606d8e4 and try to them efficiently in a single traversal for some cases f5221803ffa9f3878880efb462cdc9eea606d8e4 and 84b560ed962213b944c8b9b35ce31838be8b7a27.