### PR TITLE
Fix data race on gMem.cSpaces in ProcessVisitAddresses

### DIFF
--- a/libpolyml/objsize.cpp
+++ b/libpolyml/objsize.cpp
@@ -112,6 +112,13 @@ ProcessVisitAddresses::ProcessVisitAddresses(bool show)
     // could allocate new local areas resulting in gMem.nlSpaces
     // and gMem.lSpaces changing under our feet.
     PLocker lock(&gMem.allocLock);
+    // gMem.cSpaces is protected by codeSpaceLock, not by allocLock, and
+    // MemMgr::AllocCodeSpace appends to it from any thread that is compiling ML.
+    // The count taken below and the loop that fills in the entries have to be
+    // inside the same lock or they can disagree and overrun the bitmaps array.
+    // Lock order is allocLock then codeSpaceLock; AllocCodeSpace acquires only
+    // codeSpaceLock, so there is no path that takes them the other way round.
+    PLocker codeLock(&gMem.codeSpaceLock);
 
     total_length = 0;
     show_size    = show;
@@ -137,6 +144,11 @@ ProcessVisitAddresses::ProcessVisitAddresses(bool show)
         bitmaps[bm++] = new VisitBitmap(space->bottom, space->top);
     }
     ASSERT(bm == nBitmaps);
+    // N.B.  This is only a snapshot.  A thread compiling ML can add a code space
+    // while the scan that follows is running; a code object in such a space has
+    // no bitmap, so ShowObject prints "Bad address" and skips it.  That does not
+    // crash and cannot corrupt the heap - the object is simply left out, so the
+    // size reported can be an under-estimate.
 
     // Clear the profile counts.
     for (unsigned i = 0; i < MAX_PROF_LEN+1; i++)


### PR DESCRIPTION
Hi @dcjm,

I received an bug report from an Isabelle user about an assertion failure in the Poly/ML runtime. I could successfully reproduce it with Poly/ML LargeHeapCompact32/ad58f3291a46ce7e88fd1849e3c2d73bf9eedce7, Isabelle 35afabf2d907, and AFP 358224adfa08:

```
isabelle build -d ~/repos/afp-devel/thys -o threads=20 -c AutoCorres2_Test
2026-09-06 11:54:38.906 java[83758:4633327] XType: Using static font registry.
Cleaned AutoCorres2_Test
Running AutoCorres2_Test ...
Assertion failed: (bm == nBitmaps), function ProcessVisitAddresses, file objsize.cpp, line 139.
/tmp/isabelle-desharna/bash_script7994499833542682190: line 1: 83788 Abort trap: 6           /Users/desharna/.isabelle/contrib/polyml-5.9.2-4/arm64_32-darwin/poly -q --minheap 500 --gcpercent 10 --enablegcsharing --gcthreads 20 --exportstats --eval \(PolyML.SaveState.loadHierarchy\ \[\"/Users/desharna/.isabelle/heaps/polyml-5.9.2_arm64_32-darwin/Pure\",\ \"/Users/desharna/.isabelle/heaps/polyml-5.9.2_arm64_32-darwin/HOL\",\ \"/Users/desharna/.isabelle/heaps/polyml-5.9.2_arm64_32-darwin/Simpl\",\ \"/Users/desharna/.isabelle/heaps/polyml-5.9.2_arm64_32-darwin/AutoCorres2_Main\"\]\;\ PolyML.print_depth\ 0\) --eval Options.load_process_default\ \(\) --eval Resources.init_session_env\ \(\) --eval Command_Line.tool\ \(fn\ \(\)\ \=\>\ \(Isabelle_Process.init_build\ \(\)\)\)\;
AutoCorres2_Test FAILED (see also "isabelle build_log -H Error AutoCorres2_Test")

Unfinished session(s): AutoCorres2_Test
0:01:04 elapsed time, 0:15:22 cpu time, factor 14.29
```

The Isabelle session calls the `PolyML.objSize` family of functions while new code is being compiled. This can lead to a race condition in the `ProcessVisitAddresses` constructor. I have a [small SML test program](https://github.com/user-attachments/files/31882219/objsize_race.sml.txt) that can nondeterministically but with a high probability reproduce the bug within 1 to 2 seconds:

```sh
$ ./poly -q < objsize_race.sml
poly: objsize.cpp:139: ProcessVisitAddresses::ProcessVisitAddresses(bool): Assertion `bm == nBitmaps' failed.
Abandon
```

The lock `gMem.allocLock` already gets acquired to protect some of the data structures, but it looks like the lock `gMem.codeSpaceLock` would also be necessary. After adding it, the test program does not reproduce the bug within the 60-second timeout:

```sh
$ ./poly -q < objsize_race.sml
no crash -- try again
```

Alternatively, couldn't the code be refactored to be completely lock free? Even with the current locks, the reported size could still be under-reported if some reference to a closure gets changed during the traversal to point to newly compiled code. By documenting that the object size is a lower bound, maybe the code could be made lock free...

Acquiring the lock for the entirety of the traversal could potentially block code generation for a long time if `PolyML.objSize` is called on big objects...

Kind regards,
Martin

NB: I could also reproduce the bug on master and the fix should also be applied there.